### PR TITLE
call getCell().clear if it exists in the hoc

### DIFF
--- a/bluecellulab/cell/core.py
+++ b/bluecellulab/cell/core.py
@@ -946,7 +946,7 @@ class Cell(InjectableMixin, PlottableMixin):
         """Delete the cell."""
         self.delete_plottable()
         if hasattr(self, 'cell') and self.cell is not None:
-            if self.cell.getCell() is not None:
+            if self.cell.getCell() is not None and hasattr(self.cell.getCell(), 'clear'):
                 self.cell.getCell().clear()
 
             self.connections = None


### PR DESCRIPTION
Some hoc files do not have the clear function. This PR modifies the delete function to call clear if it exists 