### PR TITLE
gh-actions: avoid duplicated runs by both release and test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   call-test-workflow:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,7 @@ on:
     pull_request:
     # allows this workflow to be reusable (e.g. by the build workflow)
     workflow_call:
-    push:
-      branches:
-        - main
+
 
 jobs:
   tests:


### PR DESCRIPTION
Currently the tests are run twice on main at the same time, this PR fixes it by changing the following:

* Release already triggers tests, tests won't need to be triggered explicitly.
* Push to main makes a release, tag does not need to trigger the release explicitly.