### PR TITLE
disable snap's circuit validator for simulations

### DIFF
--- a/bluecellulab/circuit/config/simulation_config.py
+++ b/bluecellulab/circuit/config/simulation_config.py
@@ -25,7 +25,6 @@ if BLUEPY_AVAILABLE:
     from bluepy_configfile.configfile import BlueConfig
     from bluepy.utils import open_utf8
 from bluepysnap import Simulation as SnapSimulation
-from bluepysnap.circuit_validation import validate as validate_circuit
 
 from bluecellulab.circuit.config.sections import Conditions, ConnectionOverrides
 from bluecellulab.stimuli import Stimulus
@@ -307,10 +306,6 @@ class SonataSimulationConfig:
             self.impl = config
         else:
             raise TypeError("Invalid config type.")
-
-        # run snap's circuit validation to early detect errors
-        circuit_config_path = self.impl.config["network"]
-        validate_circuit(circuit_config_path, skip_slow=False, only_errors=True)
 
     def get_all_projection_names(self) -> list[str]:
         unique_names = {

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setuptools.setup(
         "NEURON>=8.0.2,<9.0.0",
         "numpy>=1.8.0,<2.0.0",
         "matplotlib>=3.0.0,<4.0.0",
-        "pandas>=1.0.0,<2.0.0",
+        "pandas>=1.0.0,<3.0.0",
         "bluepysnap>=1.0.5,<2.0.0",
         "pydantic>=1.10.2,<2.0.0",
     ],


### PR DESCRIPTION
Although validating the circuit allows us to early-detect errors, it is becoming a performance bottleneck for simulations.
The circuit validator should be performed using snap before running the simulations.
 snap has already a python api and a command line option for validating the circuit. There is no need to add a wrapper to it in bluecellulab (simulation level software)

![Screenshot_20230717_103449](https://github.com/BlueBrain/BlueCelluLab/assets/7026020/53033551-e209-4fcc-9463-4b99e39e0631)
