### PR TITLE
Correction in SSim's docs

### DIFF
--- a/bluecellulab/cell/core.py
+++ b/bluecellulab/cell/core.py
@@ -535,19 +535,8 @@ class Cell(InjectableMixin, PlottableMixin):
 
         return True
 
-    def add_replay_delayed_weight(self, sid, delay, weight):
-        """Add a synaptic weight for sid that will be set with a time delay.
-
-        Parameters
-        ----------
-        sid : int
-              synapse id
-        delay : float
-                synaptic delay
-        weight : float
-                 synaptic weight
-        """
-
+    def add_replay_delayed_weight(self, sid: int, delay: float, weight: float) -> None:
+        """Add a synaptic weight for sid that will be set with a time delay."""
         self.delayed_weights.put((delay, (sid, weight)))
 
     def pre_gids(self):

--- a/bluecellulab/ssim.py
+++ b/bluecellulab/ssim.py
@@ -583,15 +583,15 @@ class SSim:
 
         Parameters
         ----------
-        t_stop : 
+        t_stop :
             This function will run the simulation until t_stop
-        v_init : 
+        v_init :
             Voltage initial value when the simulation starts
-        celsius : 
+        celsius :
             Temperature at which the simulation runs
-        dt : 
+        dt :
             Timestep (delta-t) for the simulation
-        forward_skip : 
+        forward_skip :
                        [compatibility/non-sonata] Enable/disable ForwardSkip, when
                        forward_skip_value is None, forward skip will only be
                        enabled if the simulation config has a ForwardSkip value)
@@ -599,12 +599,12 @@ class SSim:
                        [compatibility/non-sonata] Overwrite the ForwardSkip value
                        in the simulation config. If this is set to None, the value
                        in the simulation config is used.
-        cvode : 
+        cvode :
                 Force the simulation to run in variable timestep. Not possible
                 when there are stochastic channels in the neuron model. When
                 enabled results from a large network simulation will not be
                 exactly reproduced.
-        show_progress: 
+        show_progress:
                        Show a progress bar during simulations. When
                        enabled results from a large network simulation
                        will not be exactly reproduced.

--- a/bluecellulab/ssim.py
+++ b/bluecellulab/ssim.py
@@ -182,7 +182,7 @@ class SSim:
                             True.
         add_projections:
                          If True, adds all of the projection blocks of the
-                         simulation config. If False, no projections are added.
+                         circuit config. If False, no projections are added.
                          If list, adds only the projections in the list.
         intersect_pre_gids : list of gids
                              Only add synapses to the cells if their
@@ -583,22 +583,29 @@ class SSim:
 
         Parameters
         ----------
-        t_stop : This function will run the simulation until t_stop
-        v_init : Voltage initial value when the simulation starts
-        celsius : Temperature at which the simulation runs
-        dt : Timestep (delta-t) for the simulation
-        forward_skip : Enable/disable ForwardSkip (default=True, when
+        t_stop : 
+            This function will run the simulation until t_stop
+        v_init : 
+            Voltage initial value when the simulation starts
+        celsius : 
+            Temperature at which the simulation runs
+        dt : 
+            Timestep (delta-t) for the simulation
+        forward_skip : 
+                       [compatibility/non-sonata] Enable/disable ForwardSkip, when
                        forward_skip_value is None, forward skip will only be
                        enabled if the simulation config has a ForwardSkip value)
         forward_skip_value :
-                       Overwrite the ForwardSkip value in the simulation config. If
-                       this is set to None, the value in the simulation config is
-                       used.
-        cvode : Force the simulation to run in variable timestep. Not possible
+                       [compatibility/non-sonata] Overwrite the ForwardSkip value
+                       in the simulation config. If this is set to None, the value
+                       in the simulation config is used.
+        cvode : 
+                Force the simulation to run in variable timestep. Not possible
                 when there are stochastic channels in the neuron model. When
                 enabled results from a large network simulation will not be
                 exactly reproduced.
-        show_progress: Show a progress bar during simulations. When
+        show_progress: 
+                       Show a progress bar during simulations. When
                        enabled results from a large network simulation
                        will not be exactly reproduced.
         """

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setuptools.setup(
         "NEURON>=8.0.2,<9.0.0",
         "numpy>=1.8.0,<2.0.0",
         "matplotlib>=3.0.0,<4.0.0",
-        "pandas>=1.0.0,<2.0.0",
+        "pandas>=1.0.0,<3.0.0",
         "bluepysnap>=1.0.5,<2.0.0",
         "pydantic>=1.10.2,<2.0.0",
     ],


### PR DESCRIPTION
Based on @andrisecker' feedback.

* instantiate_gids' add_projections allows users to enable/disable projections defined in the **circuit** config, not simulation config.
* mark the forward skip arguments as [compatibility/non-sonata]
* Fixes in docstring rendering