### PR TITLE
Simplify hoc template naming #6

### DIFF
--- a/bluecellulab/cell/core.py
+++ b/bluecellulab/cell/core.py
@@ -80,6 +80,7 @@ class Cell(InjectableMixin, PlottableMixin):
 
         # Load the template
         neuron_template = NeuronTemplate(template_path, morphology_path)
+        self.template_id = neuron_template.template_name  # useful to map NEURON and python objects
         self.cell = neuron_template.get_cell(template_format, gid, emodel_properties)
 
         self.soma = self.cell.getCell().soma[0]
@@ -150,6 +151,11 @@ class Cell(InjectableMixin, PlottableMixin):
         neuron.h.pop_section()  # Undoing soma push
         # self.init_psections()
         self.sonata_proxy: Optional[SonataProxy] = None
+
+    def __repr__(self) -> str:
+        base_info = f"Cell Object: {super().__repr__()}"
+        hoc_info = f"NEURON ID: {self.template_id}"
+        return f"{base_info}.\n{hoc_info}."
 
     def connect_to_circuit(self, sonata_proxy: SonataProxy) -> None:
         """Connect this cell to a circuit via sonata proxy."""

--- a/bluecellulab/cell/template.py
+++ b/bluecellulab/cell/template.py
@@ -35,8 +35,6 @@ logger = logging.getLogger(__name__)
 class NeuronTemplate:
     """NeuronTemplate representation."""
 
-    used_template_names: set[str] = set()
-
     def __init__(
         self, template_filepath: str | Path, morph_filepath: str | Path
     ) -> None:
@@ -94,8 +92,7 @@ class NeuronTemplate:
 
         return cell
 
-    @classmethod
-    def load(cls, template_filename: str) -> str:
+    def load(self, template_filename: str) -> str:
         """Read a cell template. If template name already exists, rename it.
 
         Args:
@@ -115,17 +112,9 @@ class NeuronTemplate:
         # templates load outside of bluecellulab
         template_name = "%s_bluecellulab" % template_name
         template_name = get_neuron_compliant_template_name(template_name)
-        if template_name in cls.used_template_names:
-            new_template_name = template_name
-            while new_template_name in cls.used_template_names:
-                new_template_name = "%s_x" % new_template_name
-                new_template_name = get_neuron_compliant_template_name(
-                    new_template_name
-                )
+        obj_address = hex(id(self))
+        template_name = f"{template_name}_{obj_address}"
 
-            template_name = new_template_name
-
-        cls.used_template_names.add(template_name)
         template_content = re.sub(
             r"begintemplate\s*(\S*)",
             "begintemplate %s" % template_name,

--- a/tests/test_cell/test_core.py
+++ b/tests/test_cell/test_core.py
@@ -37,9 +37,11 @@ def test_longname():
 
 def test_load_template():
     """Test the neuron template loading."""
-    fpath = parent_dir / "examples/cell_example1/test_cell.hoc"
-    template_name = NeuronTemplate.load(fpath)
-    assert template_name == "test_cell_bluecellulab"
+    hoc_path = parent_dir / "examples/cell_example1/test_cell.hoc"
+    morph_path = parent_dir / "examples/cell_example1/test_cell.asc"
+    template = NeuronTemplate(hoc_path, morph_filepath=morph_path)
+    template_name = template.template_name
+    assert template_name == f"test_cell_bluecellulab_{hex(id(template))}"
 
 
 def test_shorten_and_hash_string():

--- a/tests/test_cell/test_core.py
+++ b/tests/test_cell/test_core.py
@@ -35,6 +35,7 @@ def test_longname():
     del cell
 
 
+@pytest.mark.v5
 def test_load_template():
     """Test the neuron template loading."""
     hoc_path = parent_dir / "examples/cell_example1/test_cell.hoc"
@@ -292,6 +293,25 @@ def test_add_dendrogram():
     cell.add_step(start_time=2.0, stop_time=22.0, level=1.0)
     sim.run(24, cvode=False)
     assert Path(output_path).is_file()
+
+
+@pytest.mark.v6
+def test_repr_and_str():
+    """Test the repr and str representations of a cell object."""
+    emodel_properties = EmodelProperties(threshold_current=1.1433533430099487,
+                                         holding_current=1.4146618843078613,
+                                         ais_scaler=1.4561502933502197)
+    cell = bluecellulab.Cell(
+        "%s/examples/circuit_sonata_quick_scx/components/hoc/cADpyr_L2TPC.hoc" % str(parent_dir),
+        "%s/examples/circuit_sonata_quick_scx/components/morphologies/asc/rr110330_C3_idA.asc" % str(parent_dir),
+        template_format="v6_ais_scaler",
+        emodel_properties=emodel_properties)
+    # >>> print(cell)
+    # Cell Object: <bluecellulab.cell.core.Cell object at 0x7f73b3fb2550>.
+    # NEURON ID: cADpyr_L2TPC_bluecellulab_0x7f73b48e2510.
+
+    # make sure NEURON template name is in the string representation
+    assert cell.cell.hname().split('[')[0] in str(cell)
 
 
 @pytest.mark.v6

--- a/tests/test_cell/test_template.py
+++ b/tests/test_cell/test_template.py
@@ -25,7 +25,7 @@ def test_get_cell_with_bluepyopt_template():
     """Unit test for the get_cell method with bluepyopt_template."""
     template = NeuronTemplate(hoc_path, morph_path)
     cell = template.get_cell("bluepyopt", None, None)
-    assert cell.hname() == "bACnoljp_bluecellulab[0]"
+    assert cell.hname() == f"bACnoljp_bluecellulab_{(hex(id(template)))}[0]"
 
 
 def test_neuron_template_init():


### PR DESCRIPTION
Addresses #6 . 

* The order of template loading will not have a direct impact on the template naming.
* Cells loading the same template will have the same character lengths in their template names.


Additionally, by looking at the Python object, one can tell which underlying NEURON object it refers to.

```python
(Pdb) print(cell)
Cell Object: <bluecellulab.cell.core.Cell object at 0x7f86f325d690>.
NEURON ID: cADpyr_L2TPC_bluecellulab_0x7f86f03c2010.
(Pdb) cell.cell.hname()
'cADpyr_L2TPC_bluecellulab_0x7f86f03c2010[0]'
```