### PR TITLE
don't enforce having cao_CR_GluSynapse when extracellular_calcium is set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ nrnivmodl.log
 .mypy_cache
 .ruff_cache
 .pytest_cache
+*.btr

--- a/bluecellulab/simulation/neuron_globals.py
+++ b/bluecellulab/simulation/neuron_globals.py
@@ -19,8 +19,11 @@ from bluecellulab.exceptions import error_context
 
 
 def set_global_condition_parameters(condition_parameters: Conditions) -> None:
-    """Sets the global condition parameters in NEURON objects."""
-    if condition_parameters.extracellular_calcium is not None:
+    """Sets the global condition parameters in NEURON objects if GluSynapse is
+    available."""
+    if condition_parameters.extracellular_calcium is not None and hasattr(
+        bluecellulab.neuron.h, "cao_CR_GluSynapse"
+    ):
         cao_cr_glusynapse = condition_parameters.extracellular_calcium
         with error_context("mechanism/s for cao_CR_GluSynapse need to be compiled"):
             bluecellulab.neuron.h.cao_CR_GluSynapse = cao_cr_glusynapse

--- a/tests/test_simulation/test_neuron_globals.py
+++ b/tests/test_simulation/test_neuron_globals.py
@@ -1,0 +1,54 @@
+from unittest import mock
+import pytest
+import bluecellulab
+from bluecellulab.circuit.config.sections import ConditionEntry, Conditions, MechanismConditions
+from bluecellulab.simulation.neuron_globals import set_global_condition_parameters, set_init_depleted_values, set_minis_single_vesicle_values, set_tstop_value
+
+
+def test_set_tstop_value():
+    set_tstop_value(100.0)
+    assert bluecellulab.neuron.h.tstop == 100.0
+
+
+@mock.patch("bluecellulab.neuron.h")
+def test_set_global_condition_parameters_no_mechs(mocked_h):
+    del mocked_h.cao_CR_GluSynapse  # delete the attribute for the mock
+    calcium_condition = Conditions(extracellular_calcium=2.0)
+    set_global_condition_parameters(calcium_condition)
+    assert not hasattr(bluecellulab.neuron.h, "cao_CR_GluSynapse")
+
+    mech_conditions = Conditions(mech_conditions=MechanismConditions(None, None, None))
+    set_global_condition_parameters(mech_conditions)
+
+
+@pytest.mark.v6
+def test_set_global_condition_parameters():
+    calcium_condition = Conditions(extracellular_calcium=2.015)
+    set_global_condition_parameters(calcium_condition)
+    assert bluecellulab.neuron.h.cao_CR_GluSynapse == 2.015
+
+
+@pytest.mark.v6
+def test_set_init_depleted_values():
+    mech_conditions = MechanismConditions(
+        ampanmda=ConditionEntry(minis_single_vesicle=None, init_depleted=True),
+        gabaab=ConditionEntry(minis_single_vesicle=None, init_depleted=False),
+        glusynapse=ConditionEntry(minis_single_vesicle=None, init_depleted=None),
+    )
+    set_init_depleted_values(mech_conditions)
+    assert bluecellulab.neuron.h.init_depleted_ProbAMPANMDA_EMS == 1.0
+    assert bluecellulab.neuron.h.init_depleted_ProbGABAAB_EMS == 0.0
+    assert bluecellulab.neuron.h.init_depleted_GluSynapse == 0.0
+
+
+@pytest.mark.v6
+def test_set_minis_single_vesicle_values():
+    mech_conditions = MechanismConditions(
+        ampanmda=ConditionEntry(minis_single_vesicle=True, init_depleted=None),
+        gabaab=ConditionEntry(minis_single_vesicle=False, init_depleted=None),
+        glusynapse=ConditionEntry(minis_single_vesicle=None, init_depleted=None),
+    )
+    set_minis_single_vesicle_values(mech_conditions)
+    assert bluecellulab.neuron.h.minis_single_vesicle_ProbAMPANMDA_EMS == 1.0
+    assert bluecellulab.neuron.h.minis_single_vesicle_ProbGABAAB_EMS == 0.0
+    assert bluecellulab.neuron.h.minis_single_vesicle_GluSynapse == 0.0


### PR DESCRIPTION
`extracellular_calcium` has 2 uses
A) for scaling the synaptic release propability (for all Synapse types)
B) setting the neuron.h.cao_CR_GluSynapse (for GluSynapse only)

Previously bluecellulab was enforcing B to be mandatory. There are usecases with only A however as in the Zenodo SSCX release.

Also as mentioned in https://github.com/BlueBrain/BlueCelluLab/issues/75.