### PR TITLE
Update mechanisms loading using NEURON API

### DIFF
--- a/bluecellulab/cell/core.py
+++ b/bluecellulab/cell/core.py
@@ -20,7 +20,7 @@ import logging
 import json
 from pathlib import Path
 import queue
-from typing import Any, Optional
+from typing import Optional
 
 import numpy as np
 
@@ -41,10 +41,9 @@ from bluecellulab.neuron_interpreter import eval_neuron
 from bluecellulab.rngsettings import RNGSettings
 from bluecellulab.stimuli import SynapseReplay
 from bluecellulab.synapse import SynapseFactory, Synapse
+from bluecellulab.type_aliases import HocObjectType
 
 logger = logging.getLogger(__name__)
-
-NeuronType = Any
 
 
 class Cell(InjectableMixin, PlottableMixin):
@@ -74,7 +73,7 @@ class Cell(InjectableMixin, PlottableMixin):
         super().__init__()
         # Persistent objects, like clamps, that exist as long
         # as the object exists
-        self.persistent: list[NeuronType] = []
+        self.persistent: list[HocObjectType] = []
 
         self.morphology_path = morphology_path
 
@@ -99,12 +98,12 @@ class Cell(InjectableMixin, PlottableMixin):
         else:
             self.rng_settings = rng_settings
 
-        self.recordings: dict[str, NeuronType] = {}
+        self.recordings: dict[str, HocObjectType] = {}
         self.synapses: dict[int, Synapse] = {}
         self.connections: dict[int, bluecellulab.Connection] = {}
 
-        self.ips: dict[int, NeuronType] = {}
-        self.syn_mini_netcons: dict[int, NeuronType] = {}
+        self.ips: dict[int, HocObjectType] = {}
+        self.syn_mini_netcons: dict[int, HocObjectType] = {}
         self.serialized = None
 
         # Be careful when removing this,
@@ -122,7 +121,7 @@ class Cell(InjectableMixin, PlottableMixin):
 
         self.delayed_weights = queue.PriorityQueue()  # type: ignore
         self.secname_to_isec: dict[str, int] = {}
-        self.secname_to_hsection: dict[str, NeuronType] = {}
+        self.secname_to_hsection: dict[str, HocObjectType] = {}
         self.secname_to_psection: dict[str, psection.PSection] = {}
 
         self.emodel_properties = emodel_properties

--- a/bluecellulab/cell/injector.py
+++ b/bluecellulab/cell/injector.py
@@ -36,6 +36,8 @@ from bluecellulab.stimuli import (
     RelativeOrnsteinUhlenbeck,
     RelativeShotNoise,
 )
+from bluecellulab.type_aliases import HocObjectType
+
 
 logger = logging.getLogger(__name__)
 
@@ -450,9 +452,9 @@ class InjectableMixin:
         tau: float,
         gmax: float,
         e: float,
-        section: bluecellulab.neuron.hoc.HocObject,
+        section: HocObjectType,
         segx=0.5,
-    ) -> bluecellulab.neuron.hoc.HocObject:
+    ) -> HocObjectType:
         """Add an AlphaSynapse NEURON point process stimulus to the cell."""
         syn = bluecellulab.neuron.h.AlphaSynapse(segx, sec=section)
         syn.onset = onset

--- a/bluecellulab/cell/random.py
+++ b/bluecellulab/cell/random.py
@@ -14,15 +14,15 @@
 """Contains probability distributions."""
 
 from math import log, sqrt
-from typing import Any
 
-from bluecellulab import neuron
+import neuron
 
-NEURON_RNG = Any
+
+from bluecellulab.type_aliases import NeuronRNG, NeuronVector
 
 
 # Gamma-distributed sample generator (not available in NEURON)
-def gamma(rng: NEURON_RNG, a: float, b: float, N: int = 1) -> neuron.h.Vector:
+def gamma(rng: NeuronRNG, a: float, b: float, N: int = 1) -> NeuronVector:
     """Sample N variates from a gamma distribution with parameters shape = a,
     scale = b using the NEURON random number generator rng.
 

--- a/bluecellulab/cell/template.py
+++ b/bluecellulab/cell/template.py
@@ -26,6 +26,7 @@ import bluecellulab
 from bluecellulab import neuron
 from bluecellulab.circuit import EmodelProperties
 from bluecellulab.exceptions import BluecellulabError
+from bluecellulab.type_aliases import HocObjectType
 
 import logging
 
@@ -54,7 +55,7 @@ class NeuronTemplate:
 
     def get_cell(
         self, template_format: str, gid: Optional[int], emodel_properties: Optional[EmodelProperties]
-    ) -> neuron.hoc.HocObject:
+    ) -> HocObjectType:
         """Returns the hoc object matching the template format."""
         morph_dir, morph_fname = os.path.split(self.morph_filepath)
         if template_format == "v6":

--- a/bluecellulab/synapse/synapse_types.py
+++ b/bluecellulab/synapse/synapse_types.py
@@ -14,15 +14,14 @@
 """Class that represents a synapse in bluecellulab."""
 
 from __future__ import annotations
-from typing import Any, Optional
+from typing import Optional
 import pandas as pd
 import logging
 
 import bluecellulab
 from bluecellulab.circuit import SynapseProperty
+from bluecellulab.type_aliases import HocObjectType
 
-
-NeuronType = Any
 
 logger = logging.getLogger(__name__)
 
@@ -54,7 +53,7 @@ class Synapse:
         extracellular_calcium: float
                                the extracellular calcium concentration
         """
-        self.persistent: list[NeuronType] = []
+        self.persistent: list[HocObjectType] = []
         self.synapseconfigure_cmds: list[str] = []
         self._delay_weights: list[tuple[float, float]] = []
         self._weight: Optional[float] = None
@@ -65,7 +64,7 @@ class Synapse:
         self.projection, self.sid = self.syn_id
         self.extracellular_calcium = extracellular_calcium
         self.syn_description = self.update_syn_description(syn_description)
-        self.hsynapse: Optional[NeuronType] = None
+        self.hsynapse: Optional[HocObjectType] = None
 
         self.source_popid, self.target_popid = popids
 

--- a/bluecellulab/tools.py
+++ b/bluecellulab/tools.py
@@ -32,7 +32,6 @@ import logging
 import numpy as np
 
 import bluecellulab
-from bluecellulab import neuron
 from bluecellulab.circuit.circuit_access import EmodelProperties
 from bluecellulab.exceptions import UnsteadyCellError
 
@@ -99,18 +98,6 @@ class deprecated:
                 .. deprecated:: .1\n" % self.new_function
         rep_func.__dict__.update(func.__dict__)
         return rep_func
-
-
-def load_nrnmechanisms(libnrnmech_path: str) -> None:
-    """Load another shared library with NEURON mechanisms. (Created by
-    nrnivmodl)
-
-    Parameters
-    ----------
-    libnrnmech_path: string
-                     Path to a NEURON mechanisms file
-    """
-    neuron.h.nrn_load_dll(libnrnmech_path)
 
 
 def calculate_input_resistance(

--- a/bluecellulab/type_aliases.py
+++ b/bluecellulab/type_aliases.py
@@ -1,0 +1,8 @@
+"""Type aliases used within the package."""
+
+from typing_extensions import TypeAlias
+from neuron import h as hoc_type
+
+HocObjectType: TypeAlias = hoc_type   # until NEURON is typed, most NEURON types are this
+NeuronRNG: TypeAlias = hoc_type
+NeuronVector: TypeAlias = hoc_type

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setuptools.setup(
         "pandas>=1.0.0,<3.0.0",
         "bluepysnap>=1.0.5,<2.0.0",
         "pydantic>=1.10.2,<2.0.0",
+        "typing-extensions>=4.8.0"
     ],
     keywords=[
         'computational neuroscience',

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -1,0 +1,61 @@
+import os
+import pytest
+from unittest.mock import MagicMock, patch
+from bluecellulab import importer
+from bluecellulab.exceptions import BluecellulabError
+
+
+@patch("os.path.isdir", return_value=False)  # when x86_64 isdir returns False
+def test_import_mod_lib_no_env_no_folder(mocked_isdir):
+    mock_neuron = MagicMock()
+    with patch.dict(os.environ, {}, clear=True):
+        assert importer.import_mod_lib(mock_neuron) == "No mechanisms are loaded."
+
+
+def test_import_mod_lib_env_var_set_folder_exists():
+    mock_neuron = MagicMock()
+    with patch.dict(os.environ, {"BLUECELLULAB_MOD_LIBRARY_PATH": "/fake/path"}):
+        with patch(
+            "os.path.isdir", return_value=True
+        ):  # when x86_64 isdir returns True and env var is set
+            with pytest.raises(
+                BluecellulabError,
+                match="BLUECELLULAB_MOD_LIBRARY_PATH is set and current directory contains the x86_64 folder. Please remove one of them.",
+            ):
+                importer.import_mod_lib(mock_neuron)
+
+
+def test_import_mod_lib_env_var_set():
+    mock_neuron = MagicMock()
+    with patch.dict(os.environ, {"BLUECELLULAB_MOD_LIBRARY_PATH": "/fake/path"}):
+        with patch("os.path.isdir", return_value=False):
+            assert importer.import_mod_lib(mock_neuron) == "/fake/path"
+
+
+def test_import_mod_lib_no_env_with_folder():
+    mock_neuron = MagicMock()
+    with patch.dict(os.environ, {}, clear=True):
+        with patch("os.path.isdir", return_value=True):
+            assert importer.import_mod_lib(mock_neuron).endswith("x86_64")
+
+
+@patch.object(
+    importer.pkg_resources,
+    "resource_filename",
+    return_value="/fake/path/to/hoc_file.hoc",
+)
+def test_import_neurodamus(mocked_pkg_resources):
+    mock_neuron = MagicMock()
+    importer.import_neurodamus(mock_neuron)
+    assert mock_neuron.h.load_file.called
+    # Check that it was called with the expected arguments
+    mock_neuron.h.load_file.assert_any_call("/fake/path/to/hoc_file.hoc")
+
+
+@patch("builtins.print")
+def test_print_header(mocked_print):
+    mock_neuron = MagicMock(__file__="/fake/path/to/neuron")
+    importer.print_header(mock_neuron, "/fake/path/to/mod_lib")
+    # Check if the expected print calls were made
+    mocked_print.assert_any_call("Imported NEURON from: /fake/path/to/neuron")
+    mocked_print.assert_any_call("Mod lib: ", "/fake/path/to/mod_lib")


### PR DESCRIPTION
## Description

This PR uses the modern NEURON API in dealing with the mechanisms loading. 
E.g. Bluecellulab previously was only checking for the x86_64, NEURON however supports a wider range of machine architectures such as: `platform.machine(), "i686", "x86_64", "powerpc", "umac"`.

### CHANGES

* remove load_nrnmechanisms from tools, NEURON does it more comprehensively (e.g. https://github.com/neuronsimulator/nrn/blob/e0290762790622291c4867dee25a7c13e0c2d326/share/lib/python/neuron/__init__.py#L323)
* use neuron.load_mechanisms instead of neuron.h.nrn_load_dll, load_mechanisms is more comprehensive
* add type_aliases.py to annotate NEURON specific types
* remove nrn_disable_banner: no longer applicable
* Addresses #20 

### BREAKING CHANGES

* rename expected env var BGLIBPY_MOD_LIBRARY_PATH -> BLUECELLULAB_MOD_LIBRARY_PATH
* the env var expects the directory containing the mechs dir (same as in NEURON). Before, it was expecting the .so file (which is platform specific).

## TODO

Squash and tag since there's behavioural change in `import_mod_lib`.