### PR TITLE
remove RNGSettings:base_noise_seed

### DIFF
--- a/bluecellulab/rngsettings.py
+++ b/bluecellulab/rngsettings.py
@@ -32,8 +32,7 @@ class RNGSettings(metaclass=Singleton):
             self,
             mode: Optional[str] = None,
             circuit_access: Optional[CircuitAccess] = None,
-            base_seed: Optional[int] = None,
-            base_noise_seed: Optional[int] = None):
+            base_seed: Optional[int] = None):
         """Constructor.
 
         Parameters
@@ -41,7 +40,6 @@ class RNGSettings(metaclass=Singleton):
         mode : rng mode, if not specified mode is taken from circuit_access
         circuit: circuit access object, if present seeds are read from simulation
         base_seed: base seed for entire sim, overrides config value
-        base_noise_seed: base seed for the noise stimuli
         """
 
         self._mode = ""
@@ -77,11 +75,6 @@ class RNGSettings(metaclass=Singleton):
         self.minis_seed = circuit_access.config.minis_seed if circuit_access else 0
         bluecellulab.neuron.h.minisSeed = self.minis_seed
 
-        if base_noise_seed is None:
-            self.base_noise_seed = 0
-        else:
-            self.base_noise_seed = base_noise_seed
-
     @property
     def mode(self):
         return self._mode
@@ -103,14 +96,12 @@ class RNGSettings(metaclass=Singleton):
     def __repr__(self) -> str:
         """Returns a string representation of the object."""
         return "RNGSettings(mode={mode}, base_seed={base_seed}, " \
-               "base_noise_seed={base_noise_seed}, " \
                "synapse_seed={synapse_seed}, " \
                "ionchannel_seed={ionchannel_seed}, " \
                "stimulus_seed={stimulus_seed}, " \
                "minis_seed={minis_seed})".format(
                    mode=self.mode,
                    base_seed=self.base_seed,
-                   base_noise_seed=self.base_noise_seed,
                    synapse_seed=self.synapse_seed,
                    ionchannel_seed=self.ionchannel_seed,
                    stimulus_seed=self.stimulus_seed,

--- a/bluecellulab/ssim.py
+++ b/bluecellulab/ssim.py
@@ -59,7 +59,6 @@ class SSim:
         dt: float = 0.025,
         record_dt: Optional[float] = None,
         base_seed: Optional[int] = None,
-        base_noise_seed: Optional[int] = None,
         rng_mode: Optional[str] = None,
         print_cellstate: bool = False,
     ):
@@ -75,11 +74,6 @@ class SSim:
                     Has to positive integer.
                     When this is not set, and no seed is set in the
                     simulation config, the seed will be 0.
-        base_noise_seed :
-                    Base seed used for the noise stimuli in the simulation.
-                    Not setting this will result in the default Neurodamus
-                    behavior (i.e. seed=0)
-                    Has to positive integer.
         rng_mode : String with rng mode, if not specified mode is taken from
                     simulation config. Possible values are Compatibility, Random123
                     and UpdatedMCell.
@@ -103,8 +97,7 @@ class SSim:
         self.rng_settings = bluecellulab.RNGSettings(
             rng_mode,
             self.circuit_access,
-            base_seed=base_seed,
-            base_noise_seed=base_noise_seed)
+            base_seed=base_seed)
 
         self.cells: CellDict = CellDict()
 

--- a/tests/test_rngsettings.py
+++ b/tests/test_rngsettings.py
@@ -36,7 +36,7 @@ def test_str_repr_obj():
     """Test the str and repr methods of RNGSettings."""
     rng_obj = bluecellulab.RNGSettings(mode="UpdatedMCell")
     assert repr(rng_obj) == "RNGSettings(mode=UpdatedMCell, base_seed=0, " \
-                            "base_noise_seed=0, synapse_seed=0, " \
+                            "synapse_seed=0, " \
                             "ionchannel_seed=0, stimulus_seed=0, " \
                             "minis_seed=0)"
 


### PR DESCRIPTION

Within the context of https://github.com/BlueBrain/BlueCelluLab/issues/75, I am debugging the random seed settings. 

I noticed there is this deprecated `base_noise_seed` still being passed around although it's not consumed by any function.

Config specifications and Neurodamus simulator deprecated that property long ago.

At the moment:

* BlueConfig specification does not have it: https://sonata-extension.readthedocs.io/en/latest/blueconfig.html
* SONATA specification does not have it: https://sonata-extension.readthedocs.io/en/latest/sonata_simulation.html
* NEURODAMUS does not have it: https://github.com/BlueBrain/neurodamus/

Bluecellulab should also not have it.