### PR TITLE
consistent arg names&types in replay minis&synapses

### DIFF
--- a/bluecellulab/circuit/circuit_access.py
+++ b/bluecellulab/circuit/circuit_access.py
@@ -137,7 +137,7 @@ class CircuitAccess(Protocol):
     def fetch_cell_info(self, cell_id: CellId) -> pd.Series:
         raise NotImplementedError
 
-    def fetch_mini_frequencies(self, cell_id: CellId) -> tuple:
+    def fetch_mini_frequencies(self, cell_id: CellId) -> tuple[float | None, float | None]:
         raise NotImplementedError
 
     @property
@@ -432,7 +432,7 @@ class BluepyCircuitAccess:
 
         return emodel_name
 
-    def fetch_mini_frequencies(self, cell_id: CellId) -> tuple:
+    def fetch_mini_frequencies(self, cell_id: CellId) -> tuple[float | None, float | None]:
         """Get inhibitory frequency of gid."""
         cell_info = self.fetch_cell_info(cell_id)
         # mvd uses inh_mini_frequency, sonata uses inh-mini_frequency
@@ -650,7 +650,7 @@ class SonataCircuitAccess:
     def fetch_cell_info(self, cell_id: CellId) -> pd.Series:
         return self._circuit.nodes[cell_id.population_name].get(cell_id.id)
 
-    def fetch_mini_frequencies(self, cell_id: CellId) -> tuple:
+    def fetch_mini_frequencies(self, cell_id: CellId) -> tuple[float | None, float | None]:
         cell_info = self.fetch_cell_info(cell_id)
         exc_mini_frequency = cell_info['exc-mini_frequency'] \
             if 'exc-mini_frequency' in cell_info else None

--- a/bluecellulab/ssim.py
+++ b/bluecellulab/ssim.py
@@ -542,7 +542,9 @@ class SSim:
                     syn_description,
                     syn_connection_parameters,
                     popids=popids,
-                    mini_frequencies=mini_frequencies)
+                    mini_frequencies=mini_frequencies,
+                    base_seed=None
+                )
 
     def run(
         self,


### PR DESCRIPTION
Uses consistent argument names and argument types between add_replay_minis and add_replay_synapses.

It revealed base_seed argument required for add_replay_minis was not getting set by the SSim call. Now SSim intentionally passes a None (same behaviour as before, more explicit). This is possibly related to https://github.com/BlueBrain/BlueCelluLab/issues/75.

