### PR TITLE
Updating the terminology in api and docstring of Cell

### DIFF
--- a/bluecellulab/cell/core.py
+++ b/bluecellulab/cell/core.py
@@ -429,7 +429,7 @@ class Cell(InjectableMixin, PlottableMixin):
         self.recordings[var_name] = recording
 
     @staticmethod
-    def get_precise_record_dt(dt):
+    def get_precise_record_dt(dt: float) -> float:
         """Get a more precise record_dt to make time points faill on dts."""
         return (1.0 + neuron.h.float_epsilon) / (1.0 / dt)
 

--- a/bluecellulab/cell/core.py
+++ b/bluecellulab/cell/core.py
@@ -281,14 +281,14 @@ class Cell(InjectableMixin, PlottableMixin):
         self.is_made_passive = True
 
     def enable_ttx(self) -> None:
-        """Add TTX to the bath (i.e. block the Na channels)."""
+        """Add TTX to the environment (i.e. block the Na channels)."""
         if hasattr(self.cell.getCell(), 'enable_ttx'):
             self.cell.getCell().enable_ttx()
         else:
             self._default_enable_ttx()
 
     def disable_ttx(self) -> None:
-        """Add TTX to the bath (i.e. block the Na channels)."""
+        """Add TTX to the environment (i.e. block the Na channels)."""
         if hasattr(self.cell.getCell(), 'disable_ttx'):
             self.cell.getCell().disable_ttx()
         else:

--- a/bluecellulab/cell/core.py
+++ b/bluecellulab/cell/core.py
@@ -469,7 +469,7 @@ class Cell(InjectableMixin, PlottableMixin):
                 syn_id_list.append(syn_id)
         return syn_id_list
 
-    def create_netcon_spikedetector(self, target, location: str, threshold: float = -30.0):
+    def create_netcon_spikedetector(self, target: HocObjectType, location: str, threshold: float = -30.0) -> HocObjectType:
         """Add and return a spikedetector.
 
         This is a NetCon that detects spike in the current cell, and that
@@ -481,6 +481,9 @@ class Cell(InjectableMixin, PlottableMixin):
             threshold: spike detection threshold
 
         Returns: Neuron netcon object
+
+        Raises:
+            ValueError: If the spike detection location is not 'soma' or 'AIS'.
         """
         if location == "soma":
             sec = self.cell.getCell().soma[0]
@@ -489,13 +492,12 @@ class Cell(InjectableMixin, PlottableMixin):
             sec = self.cell.getCell().axon[1]
             source = self.cell.getCell().axon[1](0.5)._ref_v
         else:
-            raise Exception("Spike detection location must be soma or AIS")
+            raise ValueError("Spike detection location must be soma or AIS")
         netcon = bluecellulab.neuron.h.NetCon(source, target, sec=sec)
         netcon.threshold = threshold
-
         return netcon
 
-    def start_recording_spikes(self, target, location: str, threshold: float = -30):
+    def start_recording_spikes(self, target: HocObjectType, location: str, threshold: float = -30) -> None:
         """Start recording spikes in the current cell.
 
         Args:

--- a/bluecellulab/cell/core.py
+++ b/bluecellulab/cell/core.py
@@ -203,7 +203,7 @@ class Cell(InjectableMixin, PlottableMixin):
         """Returns the id of the section with name secname."""
         return self.secname_to_psection[secname].isec
 
-    def re_init_rng(self, use_random123_stochkv=None):
+    def re_init_rng(self, use_random123_stochkv: bool = False) -> None:
         """Reinitialize the random number generator for stochastic channels."""
 
         if not self.is_made_passive:

--- a/bluecellulab/cell/core.py
+++ b/bluecellulab/cell/core.py
@@ -292,7 +292,7 @@ class Cell(InjectableMixin, PlottableMixin):
             self._default_enable_ttx()
 
     def disable_ttx(self) -> None:
-        """Add TTX to the environment (i.e. block the Na channels).
+        """Remove TTX from the environment (i.e. unblock the Na channels).
 
         Disable TTX by inserting TTXDynamicsSwitch and setting ttxo to
         1e-14

--- a/bluecellulab/cell/core.py
+++ b/bluecellulab/cell/core.py
@@ -632,25 +632,6 @@ class Cell(InjectableMixin, PlottableMixin):
             self.ips[synapse_id].setTbins(tbins_vec)
             self.ips[synapse_id].setRate(rate_vec)
 
-    def locate_bapsite(self, seclist_name, distance):
-        """Return the location of the BAP site.
-
-        Parameters
-        ----------
-
-        seclist_name : str
-            SectionList to search in
-        distance : float
-            Distance from soma
-
-        Returns
-        -------
-
-        list of sections at the specified distance from the soma
-        """
-        return [x for x in self.cell.getCell().locateBAPSite(seclist_name,
-                                                             distance)]
-
     def get_childrensections(self, parentsection):
         """Get the children section of a neuron section.
 

--- a/bluecellulab/cell/core.py
+++ b/bluecellulab/cell/core.py
@@ -325,20 +325,9 @@ class Cell(InjectableMixin, PlottableMixin):
                 section.insert('TTXDynamicsSwitch')
             section.ttxo_level_TTXDynamicsSwitch = 1e-14
 
-    def area(self):
-        """Calculate the total area of the cell.
-
-        Parameters
-        ----------
-
-
-        Returns
-        -------
-        area : float
-               Total surface area of the cell
-        """
-        # pylint: disable=C0103
-        area = 0
+    def area(self) -> float:
+        """The total surface area of the cell."""
+        area = 0.0
         for section in self.all:
             x_s = np.arange(1.0 / (2 * section.nseg), 1.0,
                             1.0 / (section.nseg))

--- a/bluecellulab/cell/core.py
+++ b/bluecellulab/cell/core.py
@@ -47,28 +47,30 @@ logger = logging.getLogger(__name__)
 
 
 class Cell(InjectableMixin, PlottableMixin):
-    """Represents a BGLib Cell object."""
+    """Represents a Cell object."""
 
-    def __init__(self, template_path: str | Path, morphology_path: str | Path,
-                 gid=0, record_dt=None, template_format="v5",
+    def __init__(self,
+                 template_path: str | Path,
+                 morphology_path: str | Path,
+                 gid: int = 0,
+                 record_dt: Optional[float] = None,
+                 template_format: str = "v5",
                  emodel_properties: Optional[EmodelProperties] = None,
-                 rng_settings: Optional[RNGSettings] = None):
-        """Constructor.
+                 rng_settings: Optional[RNGSettings] = None) -> None:
+        """Initializes a Cell object.
 
-        Parameters
-        ----------
-        template_path : Full path to BGLib template to be loaded
-        morphology_path : path to morphology file
-        gid : integer
-             GID of the instantiated cell (default: 0)
-        record_dt : float
-                   Force a different timestep for the recordings
-                   (default: None)
-        template_format: str
-                         cell template format such as v6 or v6_air_scaler.
-        emodel_properties: properties such as threshold_current, holding_current
-        rng_settings: bluecellulab.RNGSettings
-                      random number generation setting object used by the Cell.
+        Args:
+            template_path: Full path to hoc template file.
+            morphology_path: Path to morphology file.
+            gid: ID of the cell, used in RNG seeds. Defaults to 0.
+            record_dt: Timestep for the recordings.
+                If not provided, a default is used. Defaults to None.
+            template_format: Cell template format such as 'v5'
+                or 'v6_air_scaler'. Defaults to "v5".
+            emodel_properties: Properties such as
+                threshold_current, holding_current. Defaults to None.
+            rng_settings: Random number generation setting
+                object used by the Cell. Defaults to None.
         """
         super().__init__()
         # Persistent objects, like clamps, that exist as long

--- a/bluecellulab/cell/core.py
+++ b/bluecellulab/cell/core.py
@@ -106,7 +106,7 @@ class Cell(InjectableMixin, PlottableMixin):
 
         self.ips: dict[tuple[str, int], HocObjectType] = {}
         self.syn_mini_netcons: dict[tuple[str, int], HocObjectType] = {}
-        self.serialized = None
+        self.serialized: SerializedSections | None = None
 
         # Be careful when removing this,
         # time recording needs this push
@@ -162,7 +162,7 @@ class Cell(InjectableMixin, PlottableMixin):
         """Connect this cell to a circuit via sonata proxy."""
         self.sonata_proxy = sonata_proxy
 
-    def init_psections(self):
+    def init_psections(self) -> None:
         """Initialize the psections list.
 
         This list contains the Python representation of the psections of
@@ -199,15 +199,9 @@ class Cell(InjectableMixin, PlottableMixin):
                 pchild = self.get_psection(secname=childname)
                 psec.add_pchild(pchild)
 
-    def get_section_id(self, secname=None):
-        """Get section based on section id.
-
-        Returns
-        -------
-        integer: section id
-                 section id of the section with name secname
-        """
-        return self.secname_to_psection[secname].section_id
+    def get_section_id(self, secname: str) -> int:
+        """Returns the id of the section with name secname."""
+        return self.secname_to_psection[secname].isec
 
     def re_init_rng(self, use_random123_stochkv=None):
         """Reinitialize the random number generator for stochastic channels."""

--- a/bluecellulab/cell/core.py
+++ b/bluecellulab/cell/core.py
@@ -385,7 +385,7 @@ class Cell(InjectableMixin, PlottableMixin):
         if distance < 0:
             logger.warning(f"synlocation_to_segx found negative distance \
                         at curr_sec({neuron.h.secname(sec=curr_sec)}) syn_offset: {syn_offset}")
-            return 0
+            return 0.0
         else:
             return distance
 

--- a/bluecellulab/cell/core.py
+++ b/bluecellulab/cell/core.py
@@ -632,14 +632,8 @@ class Cell(InjectableMixin, PlottableMixin):
             self.ips[synapse_id].setTbins(tbins_vec)
             self.ips[synapse_id].setRate(rate_vec)
 
-    def get_childrensections(self, parentsection):
-        """Get the children section of a neuron section.
-
-        Returns
-        -------
-
-        list of sections : child sections of the specified parent section
-        """
+    def get_childrensections(self, parentsection: HocObjectType) -> list[HocObjectType]:
+        """Get the children section of a neuron section."""
         number_children = neuron.h.SectionRef(sec=parentsection).nchild()
         children = []
         for index in range(0, int(number_children)):
@@ -647,14 +641,8 @@ class Cell(InjectableMixin, PlottableMixin):
         return children
 
     @staticmethod
-    def get_parentsection(childsection):
-        """Get the parent section of a neuron section.
-
-        Returns
-        -------
-
-        section : parent section of the specified child section
-        """
+    def get_parentsection(childsection: HocObjectType) -> HocObjectType:
+        """Get the parent section of a neuron section."""
         return neuron.h.SectionRef(sec=childsection).parent
 
     def addAxialCurrentRecordings(self, section):

--- a/bluecellulab/cell/core.py
+++ b/bluecellulab/cell/core.py
@@ -266,9 +266,8 @@ class Cell(InjectableMixin, PlottableMixin):
             ) from e
         return sec_ref.sec
 
-    def make_passive(self):
+    def make_passive(self) -> None:
         """Make the cell passive by deactivating all the active channels."""
-
         for section in self.all:
             mech_names = set()
             for seg in section:
@@ -280,33 +279,29 @@ class Cell(InjectableMixin, PlottableMixin):
                     neuron.h('uninsert %s' % mech_name, sec=section)
         self.is_made_passive = True
 
-    def enable_ttx(self):
-        """Add TTX to the bath (i.e. block the Na channels)"""
-
+    def enable_ttx(self) -> None:
+        """Add TTX to the bath (i.e. block the Na channels)."""
         if hasattr(self.cell.getCell(), 'enable_ttx'):
             self.cell.getCell().enable_ttx()
         else:
             self._default_enable_ttx()
 
-    def disable_ttx(self):
-        """Add TTX to the bath (i.e. block the Na channels)"""
-
+    def disable_ttx(self) -> None:
+        """Add TTX to the bath (i.e. block the Na channels)."""
         if hasattr(self.cell.getCell(), 'disable_ttx'):
             self.cell.getCell().disable_ttx()
         else:
             self._default_disable_ttx()
 
-    def _default_enable_ttx(self):
+    def _default_enable_ttx(self) -> None:
         """Default enable_ttx implementation."""
-
         for section in self.all:
             if not neuron.h.ismembrane("TTXDynamicsSwitch"):
                 section.insert('TTXDynamicsSwitch')
             section.ttxo_level_TTXDynamicsSwitch = 1.0
 
-    def _default_disable_ttx(self):
+    def _default_disable_ttx(self) -> None:
         """Default disable_ttx implementation."""
-
         for section in self.all:
             if not neuron.h.ismembrane("TTXDynamicsSwitch"):
                 section.insert('TTXDynamicsSwitch')

--- a/bluecellulab/cell/core.py
+++ b/bluecellulab/cell/core.py
@@ -820,11 +820,5 @@ class Cell(InjectableMixin, PlottableMixin):
             for persistent_object in self.persistent:
                 del persistent_object
 
-    @property
-    def hsynapses(self):
-        """Contains a dictionary of all the hoc synapses in the cell with as
-        key the gid."""
-        return {gid: synapse.hsynapse for (gid, synapse) in self.synapses.items()}
-
     def __del__(self):
         self.delete()

--- a/bluecellulab/cell/core.py
+++ b/bluecellulab/cell/core.py
@@ -281,14 +281,22 @@ class Cell(InjectableMixin, PlottableMixin):
         self.is_made_passive = True
 
     def enable_ttx(self) -> None:
-        """Add TTX to the environment (i.e. block the Na channels)."""
+        """Add TTX to the environment (i.e. block the Na channels).
+
+        Enable TTX by inserting TTXDynamicsSwitch and setting ttxo to
+        1.0
+        """
         if hasattr(self.cell.getCell(), 'enable_ttx'):
             self.cell.getCell().enable_ttx()
         else:
             self._default_enable_ttx()
 
     def disable_ttx(self) -> None:
-        """Add TTX to the environment (i.e. block the Na channels)."""
+        """Add TTX to the environment (i.e. block the Na channels).
+
+        Disable TTX by inserting TTXDynamicsSwitch and setting ttxo to
+        1e-14
+        """
         if hasattr(self.cell.getCell(), 'disable_ttx'):
             self.cell.getCell().disable_ttx()
         else:

--- a/bluecellulab/ssim.py
+++ b/bluecellulab/ssim.py
@@ -46,6 +46,7 @@ from bluecellulab.simulation import (
     set_global_condition_parameters,
     set_tstop_value
 )
+from bluecellulab.synapse.synapse_types import SynapseID
 
 logger = logging.getLogger(__name__)
 
@@ -513,7 +514,7 @@ class SSim:
                     None, location=self.spike_location, threshold=self.spike_threshold)
                 self.pc.cell(cell_id.id, nc)  # register cell spike detector
 
-    def _instantiate_synapse(self, cell_id: CellId, syn_id: tuple[str, int], syn_description,
+    def _instantiate_synapse(self, cell_id: CellId, syn_id: SynapseID, syn_description,
                              add_minis=False, popids=(0, 0)) -> None:
         """Instantiate one synapse for a given gid, syn_id and
         syn_description."""

--- a/tests/test_cell/test_core.py
+++ b/tests/test_cell/test_core.py
@@ -352,6 +352,17 @@ class TestCellV6:
         """Test the cell's area computation."""
         assert self.cell.area() == 5812.493415302344
 
+    def test_get_childrensections(self):
+        """Test the get_childrensections method."""
+        res = self.cell.get_childrensections(self.cell.soma)
+        assert len(res) == 3
+
+    def test_get_parentsection(self):
+        """Test the get_parentsection method."""
+        section = self.cell.get_childrensections(self.cell.soma)[0]
+        res = self.cell.get_parentsection(section)
+        assert res == self.cell.soma
+
 
 @pytest.mark.v6
 def test_add_synapse_replay():

--- a/tests/test_cell/test_core.py
+++ b/tests/test_cell/test_core.py
@@ -261,20 +261,34 @@ class TestCellBaseClassVClamp:
         assert current_after_vc_end == 0.0
 
 
-@pytest.mark.v5
-def test_get_recorded_spikes():
-    """Cell: Test get_recorded_spikes."""
-    cell = bluecellulab.Cell(
-        "%s/examples/cell_example1/test_cell.hoc" % str(parent_dir),
-        "%s/examples/cell_example1" % str(parent_dir))
-    sim = bluecellulab.Simulation()
-    sim.add_cell(cell)
-    cell.start_recording_spikes(None, "soma", -30)
-    cell.add_step(start_time=2.0, stop_time=22.0, level=1.0)
-    sim.run(24, cvode=False)
-    spikes = cell.get_recorded_spikes("soma")
-    ground_truth = [3.350000000100014, 11.52500000009988, 19.9750000000994]
-    assert np.allclose(spikes, ground_truth)
+class TestCellSpikes:
+
+    def setup(self):
+        self.cell = bluecellulab.Cell(
+            f"{parent_dir}/examples/cell_example1/test_cell.hoc",
+            f"{parent_dir}/examples/cell_example1")
+        self.sim = bluecellulab.Simulation()
+        self.sim.add_cell(self.cell)
+
+    @pytest.mark.v5
+    def test_get_recorded_spikes(self):
+        """Cell: Test get_recorded_spikes."""
+        self.cell.start_recording_spikes(None, "soma", -30)
+        self.cell.add_step(start_time=2.0, stop_time=22.0, level=1.0)
+        self.sim.run(24, cvode=False)
+        spikes = self.cell.get_recorded_spikes("soma")
+        ground_truth = [3.350000000100014, 11.52500000009988, 19.9750000000994]
+        assert np.allclose(spikes, ground_truth)
+
+    @pytest.mark.v5
+    def test_create_netcon_spikedetector(self):
+        """Cell: create_netcon_spikedetector."""
+        threshold = -29.0
+        netcon = self.cell.create_netcon_spikedetector(None, "AIS", -29.0)
+        assert netcon.threshold == threshold
+        netcon = self.cell.create_netcon_spikedetector(None, "soma", -29.0)
+        with pytest.raises(ValueError):
+            self.cell.create_netcon_spikedetector(None, "Dendrite", -29.0)
 
 
 @pytest.mark.v6
@@ -337,6 +351,10 @@ class TestCellV6:
     def test_area(self):
         """Test the cell's area computation."""
         assert self.cell.area() == 5812.493415302344
+
+    def test_locate_bapsite(self):
+        """Unit test for Cell::locate_bapsite."""
+        
 
 
 @pytest.mark.v6

--- a/tests/test_cell/test_core.py
+++ b/tests/test_cell/test_core.py
@@ -297,42 +297,43 @@ def test_add_dendrogram():
 
 
 @pytest.mark.v6
-def test_repr_and_str():
-    """Test the repr and str representations of a cell object."""
-    emodel_properties = EmodelProperties(threshold_current=1.1433533430099487,
-                                         holding_current=1.4146618843078613,
-                                         ais_scaler=1.4561502933502197,
-                                         soma_scaler=1.0)
-    cell = bluecellulab.Cell(
-        "%s/examples/circuit_sonata_quick_scx/components/hoc/cADpyr_L2TPC.hoc" % str(parent_dir),
-        "%s/examples/circuit_sonata_quick_scx/components/morphologies/asc/rr110330_C3_idA.asc" % str(parent_dir),
-        template_format="v6_adapted",
-        emodel_properties=emodel_properties)
-    # >>> print(cell)
-    # Cell Object: <bluecellulab.cell.core.Cell object at 0x7f73b3fb2550>.
-    # NEURON ID: cADpyr_L2TPC_bluecellulab_0x7f73b48e2510.
+class TestCellV6:
+    """Test class for testing Cell object functionalities with v6 template."""
 
-    # make sure NEURON template name is in the string representation
-    assert cell.cell.hname().split('[')[0] in str(cell)
+    def setup(self):
+        """Setup."""
+        emodel_properties = EmodelProperties(
+            threshold_current=1.1433533430099487,
+            holding_current=1.4146618843078613,
+            ais_scaler=1.4561502933502197,
+            soma_scaler=1.0
+        )
+        self.cell = bluecellulab.Cell(
+            "%s/examples/circuit_sonata_quick_scx/components/hoc/cADpyr_L2TPC.hoc" % str(parent_dir),
+            "%s/examples/circuit_sonata_quick_scx/components/morphologies/asc/rr110330_C3_idA.asc" % str(parent_dir),
+            template_format="v6_adapted",
+            emodel_properties=emodel_properties
+        )
 
+    def test_repr_and_str(self):
+        """Test the repr and str representations of a cell object."""
+        # >>> print(cell)
+        # Cell Object: <bluecellulab.cell.core.Cell object at 0x7f73b3fb2550>.
+        # NEURON ID: cADpyr_L2TPC_bluecellulab_0x7f73b48e2510.
+        # make sure NEURON template name is in the string representation
+        assert self.cell.cell.hname().split('[')[0] in str(self.cell)
 
-@pytest.mark.v6
-def test_get_section_id():
-    """Test the get_section_id method."""
-    emodel_properties = EmodelProperties(threshold_current=1.1433533430099487,
-                                         holding_current=1.4146618843078613,
-                                         ais_scaler=1.4561502933502197,
-                                         soma_scaler=1.0)
-    cell = bluecellulab.Cell(
-        "%s/examples/circuit_sonata_quick_scx/components/hoc/cADpyr_L2TPC.hoc" % str(parent_dir),
-        "%s/examples/circuit_sonata_quick_scx/components/morphologies/asc/rr110330_C3_idA.asc" % str(parent_dir),
-        template_format="v6_adapted",
-        emodel_properties=emodel_properties)
-    cell.init_psections()
-    assert cell.get_section_id(str(cell.soma)) == 0
-    assert cell.get_section_id(str(cell.axonal[0])) == 1
-    assert cell.get_section_id(str(cell.basal[0])) == 145
-    assert cell.get_section_id(str(cell.apical[0])) == 169
+    def test_get_section_id(self):
+        """Test the get_section_id method."""
+        self.cell.init_psections()
+        assert self.cell.get_section_id(str(self.cell.soma)) == 0
+        assert self.cell.get_section_id(str(self.cell.axonal[0])) == 1
+        assert self.cell.get_section_id(str(self.cell.basal[0])) == 145
+        assert self.cell.get_section_id(str(self.cell.apical[0])) == 169
+
+    def test_area(self):
+        """Test the cell's area computation."""
+        assert self.cell.area() == 5812.493415302344
 
 
 @pytest.mark.v6

--- a/tests/test_cell/test_core.py
+++ b/tests/test_cell/test_core.py
@@ -352,10 +352,6 @@ class TestCellV6:
         """Test the cell's area computation."""
         assert self.cell.area() == 5812.493415302344
 
-    def test_locate_bapsite(self):
-        """Unit test for Cell::locate_bapsite."""
-        
-
 
 @pytest.mark.v6
 def test_add_synapse_replay():

--- a/tests/test_cell/test_core.py
+++ b/tests/test_cell/test_core.py
@@ -317,6 +317,25 @@ def test_repr_and_str():
 
 
 @pytest.mark.v6
+def test_get_section_id():
+    """Test the get_section_id method."""
+    emodel_properties = EmodelProperties(threshold_current=1.1433533430099487,
+                                         holding_current=1.4146618843078613,
+                                         ais_scaler=1.4561502933502197,
+                                         soma_scaler=1.0)
+    cell = bluecellulab.Cell(
+        "%s/examples/circuit_sonata_quick_scx/components/hoc/cADpyr_L2TPC.hoc" % str(parent_dir),
+        "%s/examples/circuit_sonata_quick_scx/components/morphologies/asc/rr110330_C3_idA.asc" % str(parent_dir),
+        template_format="v6_adapted",
+        emodel_properties=emodel_properties)
+    cell.init_psections()
+    assert cell.get_section_id(str(cell.soma)) == 0
+    assert cell.get_section_id(str(cell.axonal[0])) == 1
+    assert cell.get_section_id(str(cell.basal[0])) == 145
+    assert cell.get_section_id(str(cell.apical[0])) == 169
+
+
+@pytest.mark.v6
 def test_add_synapse_replay():
     """Cell: test add_synapse_replay."""
     sonata_sim_path = (


### PR DESCRIPTION
Some modules are following the blueconfig convention while some others follow the SONATA ones. 

This PR tries to use a consistent terminology across bluecellulab.

Type annotates the affected function signatures.
Creates `SynapseID` type to be used in function signatures.
Adds missing unit tests to the functions affected.
Deletes locate_bapsite method (not supported in the v6 hoc templates)
Deletes cell.hsynapses. It is accessible via cell.synapses[idx].hsynapse