### PR TITLE
Refactor: simplify the creation of Synapse objects #minor

### DIFF
--- a/bluecellulab/__init__.py
+++ b/bluecellulab/__init__.py
@@ -1,6 +1,5 @@
 """Package for performing single cell or network simulations and
 experiments."""
-# pylint: disable=W0401, W0611
 
 try:
     import bluepy

--- a/bluecellulab/cell/core.py
+++ b/bluecellulab/cell/core.py
@@ -341,7 +341,6 @@ class Cell(InjectableMixin, PlottableMixin):
         area : float
                Total surface area of the cell
         """
-        # pylint: disable=C0103
         area = 0
         for section in self.all:
             x_s = np.arange(1.0 / (2 * section.nseg), 1.0,
@@ -352,7 +351,6 @@ class Cell(InjectableMixin, PlottableMixin):
             #    area += bluecellulab.neuron.h.area(segment.x, sec=section)
         return area
 
-    # pylint: disable=C0103
     def add_recording(self, var_name, dt=None):
         """Add a recording to the cell.
 
@@ -583,7 +581,6 @@ class Cell(InjectableMixin, PlottableMixin):
             syn_description, self
         )
 
-        # todo: False
         if 'Weight' in connection_modifiers:
             weight_scalar = connection_modifiers['Weight']
         else:

--- a/bluecellulab/cell/core.py
+++ b/bluecellulab/cell/core.py
@@ -643,7 +643,6 @@ class Cell(InjectableMixin, PlottableMixin):
                          synapse_id: tuple[str, int],
                          syn_description: pd.Series,
                          connection_modifiers: dict,
-                         base_seed: int | None,
                          popids: tuple[int, int],
                          mini_frequencies: tuple[float | None, float | None]) -> None:
         """Add minis from the replay."""
@@ -651,8 +650,7 @@ class Cell(InjectableMixin, PlottableMixin):
 
         sid = synapse_id[1]
 
-        if base_seed is None:
-            base_seed = self.rng_settings.base_seed
+        base_seed = self.rng_settings.base_seed
         weight = syn_description[SynapseProperty.G_SYNX]
         post_sec_id = syn_description[SynapseProperty.POST_SECTION_ID]
         if "afferent_section_pos" in syn_description:

--- a/bluecellulab/cell/section_distance.py
+++ b/bluecellulab/cell/section_distance.py
@@ -35,7 +35,6 @@ class EuclideanSectionDistance:
     dimensions : string
                  planes to project on, e.g. 'xy'
     """
-    # pylint: disable=invalid-name
 
     def __call__(
             self,

--- a/bluecellulab/cell/serialized_sections.py
+++ b/bluecellulab/cell/serialized_sections.py
@@ -16,13 +16,15 @@ index."""
 
 import warnings
 import neuron
+from bluecellulab.type_aliases import HocObjectType
+
 
 warnings.filterwarnings("once", category=UserWarning, module=__name__)
 
 
 class SerializedSections:
 
-    def __init__(self, cell):
+    def __init__(self, cell: HocObjectType) -> None:
         self.isec2sec = {}
         n = cell.nSecAll
 

--- a/bluecellulab/connection.py
+++ b/bluecellulab/connection.py
@@ -95,7 +95,7 @@ class Connection:
 
         connection_dict['pre_cell_id'] = self.post_synapse.pre_gid
         connection_dict['post_cell_id'] = self.post_synapse.post_gid
-        connection_dict['post_synapse_id'] = self.post_synapse.sid
+        connection_dict['post_synapse_id'] = self.post_synapse.syn_id.sid
 
         connection_dict['post_netcon'] = {}
         connection_dict['post_netcon']['weight'] = self.post_netcon_weight

--- a/bluecellulab/dendrogram.py
+++ b/bluecellulab/dendrogram.py
@@ -15,8 +15,6 @@
 
 import numpy as np
 
-# pylint: disable=R0914,too-many-arguments
-
 
 class Dendrogram:
     """Class that represent a dendrogram plot."""

--- a/bluecellulab/plotwindow.py
+++ b/bluecellulab/plotwindow.py
@@ -50,12 +50,9 @@ class PlotWindow:
             # print dir(pylab.gca()._get_lines)
             # print pylab.gca()._get_lines.color_cycle
             # Sorry, don't see a way but disable this warning to access this
-            # pylint: disable=W0212
             colors = pylab.rcParams['axes.prop_cycle'].by_key()['color']
 
             linecolors = [x for x in itertools.islice(itertools.cycle(colors), 0, 50)]
-
-            # pylint: enable=W0212
 
             self.line[var_name] = pylab.Line2D(
                 time, recording, label=var_name,

--- a/bluecellulab/simulation/simulation.py
+++ b/bluecellulab/simulation/simulation.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Simulation class of bluecellulab."""
 
-# pylint: disable=R0913
 
 import sys
 from typing import Optional
@@ -83,7 +82,6 @@ class Simulation:
         for cell in self.cells:
             cell.init_callbacks()
 
-    # pylint: disable=C0103,R0912,R0914
     def run(
             self,
             maxtime: float,
@@ -161,7 +159,6 @@ class Simulation:
             for cell in self.cells:
                 self.pc.prcellstate(cell.gid, f"bluecellulab_t={bluecellulab.neuron.h.t}")
 
-        # pylint: disable=W0703
         try:
             neuron.h.continuerun(neuron.h.tstop)
         except Exception as exception:
@@ -179,8 +176,6 @@ class Simulation:
             neuron.h.cvode_active(cvode_old_status)
 
         logger.info("Finished simulation.")
-
-    # pylint: enable=C0103,R0912
 
     def __del__(self):
         pass

--- a/bluecellulab/ssim.py
+++ b/bluecellulab/ssim.py
@@ -14,7 +14,6 @@
 """Ssim class of bluecellulab that loads a circuit simulation to do cell
 simulations."""
 
-# pylint: disable=C0103, R0914, R0912, F0401, R0101
 
 from __future__ import annotations
 from collections.abc import Iterable
@@ -115,7 +114,6 @@ class SSim:
         condition_parameters = self.circuit_access.config.condition_parameters()
         set_global_condition_parameters(condition_parameters)
 
-    # pylint: disable=R0913
     def instantiate_gids(
         self,
         cells: int | tuple[str, int] | list[int] | list[tuple[str, int]],
@@ -437,7 +435,6 @@ class SSim:
             for k in all_keys
         }
 
-    # pylint: disable=R0913
     def _add_connections(
             self,
             add_replay=None,

--- a/bluecellulab/ssim.py
+++ b/bluecellulab/ssim.py
@@ -25,6 +25,7 @@ import logging
 
 import numpy as np
 import pandas as pd
+from pydantic.types import NonNegativeInt
 import bluecellulab
 from bluecellulab.cell import CellDict
 from bluecellulab.cell.sonata_proxy import SonataProxy
@@ -58,7 +59,7 @@ class SSim:
         simulation_config: str | Path | SimulationConfig,
         dt: float = 0.025,
         record_dt: Optional[float] = None,
-        base_seed: Optional[int] = None,
+        base_seed: Optional[NonNegativeInt] = None,
         rng_mode: Optional[str] = None,
         print_cellstate: bool = False,
     ):
@@ -71,9 +72,6 @@ class SSim:
         record_dt : Sampling interval of the recordings
         base_seed : Base seed used for this simulation. Setting this
                     will override the value set in the simulation config.
-                    Has to positive integer.
-                    When this is not set, and no seed is set in the
-                    simulation config, the seed will be 0.
         rng_mode : String with rng mode, if not specified mode is taken from
                     simulation config. Possible values are Compatibility, Random123
                     and UpdatedMCell.

--- a/bluecellulab/ssim.py
+++ b/bluecellulab/ssim.py
@@ -543,7 +543,6 @@ class SSim:
                     syn_connection_parameters,
                     popids=popids,
                     mini_frequencies=mini_frequencies,
-                    base_seed=None
                 )
 
     def run(

--- a/bluecellulab/synapse/synapse_factory.py
+++ b/bluecellulab/synapse/synapse_factory.py
@@ -22,7 +22,6 @@ import numpy as np
 import pandas as pd
 
 import bluecellulab
-from bluecellulab.exceptions import BluecellulabError
 from bluecellulab.synapse import Synapse, GabaabSynapse, AmpanmdaSynapse, GluSynapse
 from bluecellulab.circuit.config.sections import Conditions
 from bluecellulab.circuit.synapse_properties import SynapseProperties, SynapseProperty

--- a/bluecellulab/synapse/synapse_factory.py
+++ b/bluecellulab/synapse/synapse_factory.py
@@ -40,7 +40,6 @@ class SynapseFactory:
         popids: tuple[int, int],
         extracellular_calcium: float | None,
         connection_modifiers: dict,
-        base_seed: int | None = None,
     ) -> Synapse:
         """Returns a Synapse object."""
         is_inhibitory: bool = int(syn_description[SynapseProperty.TYPE]) < 100
@@ -57,12 +56,12 @@ class SynapseFactory:
             else:
                 randomize_gaba_risetime = True
             synapse = GabaabSynapse(cell, location, syn_id, syn_description,
-                                    base_seed, popids, extracellular_calcium, randomize_gaba_risetime)
+                                    popids, extracellular_calcium, randomize_gaba_risetime)
         elif syn_type == SynapseType.AMPANMDA:
-            synapse = AmpanmdaSynapse(cell, location, syn_id, syn_description, base_seed,
+            synapse = AmpanmdaSynapse(cell, location, syn_id, syn_description,
                                       popids, extracellular_calcium)
         else:
-            synapse = GluSynapse(cell, location, syn_id, syn_description, base_seed,
+            synapse = GluSynapse(cell, location, syn_id, syn_description,
                                  popids, extracellular_calcium)
 
         synapse = cls.apply_connection_modifiers(connection_modifiers, synapse)

--- a/bluecellulab/synapse/synapse_factory.py
+++ b/bluecellulab/synapse/synapse_factory.py
@@ -14,6 +14,10 @@
 """Factory that separates Synapse creation from Synapse instances."""
 from __future__ import annotations  # PEP-563 forward reference annotations
 from enum import Enum
+import logging
+
+import neuron
+import numpy as np
 
 import pandas as pd
 
@@ -25,6 +29,8 @@ from bluecellulab.circuit.synapse_properties import SynapseProperties, SynapsePr
 
 SynapseType = Enum("SynapseType", "GABAAB AMPANMDA GLUSYNAPSE")
 
+logger = logging.getLogger(__name__)
+
 
 class SynapseFactory:
     """Creates different types of Synapses."""
@@ -33,7 +39,6 @@ class SynapseFactory:
     def create_synapse(
         cls,
         cell: bluecellulab.Cell,
-        location: float,
         syn_id: tuple[str, int],
         syn_description: pd.Series,
         condition_parameters: Conditions,
@@ -48,6 +53,7 @@ class SynapseFactory:
         )
 
         syn_type = cls.determine_synapse_type(is_inhibitory, plasticity_available)
+        syn_location = cls.determine_synapse_location(syn_description, cell)
 
         synapse: Synapse
         if syn_type == SynapseType.GABAAB:
@@ -55,13 +61,13 @@ class SynapseFactory:
                 randomize_gaba_risetime = condition_parameters.randomize_gaba_rise_time
             else:
                 randomize_gaba_risetime = True
-            synapse = GabaabSynapse(cell, location, syn_id, syn_description,
+            synapse = GabaabSynapse(cell, syn_location, syn_id, syn_description,
                                     popids, extracellular_calcium, randomize_gaba_risetime)
         elif syn_type == SynapseType.AMPANMDA:
-            synapse = AmpanmdaSynapse(cell, location, syn_id, syn_description,
+            synapse = AmpanmdaSynapse(cell, syn_location, syn_id, syn_description,
                                       popids, extracellular_calcium)
         else:
-            synapse = GluSynapse(cell, location, syn_id, syn_description,
+            synapse = GluSynapse(cell, syn_location, syn_id, syn_description,
                                  popids, extracellular_calcium)
 
         synapse = cls.apply_connection_modifiers(connection_modifiers, synapse)
@@ -90,3 +96,73 @@ class SynapseFactory:
                 return SynapseType.GLUSYNAPSE
             else:
                 return SynapseType.AMPANMDA
+
+    @classmethod
+    def determine_synapse_location(cls, syn_description: pd.Series, cell: bluecellulab.Cell) -> float:
+        """Returns the location of the synapse."""
+        isec = syn_description[SynapseProperty.POST_SECTION_ID]
+
+        # old circuits don't have it, it needs to be computed via synlocation_to_segx
+        if ("afferent_section_pos" in syn_description and
+                not np.isnan(syn_description["afferent_section_pos"])):
+            # position is pre computed in SONATA
+            location = syn_description["afferent_section_pos"]
+        else:
+            ipt = syn_description[SynapseProperty.POST_SEGMENT_ID]
+            syn_offset = syn_description[SynapseProperty.POST_SEGMENT_OFFSET]
+            location = cls.synlocation_to_segx(cell, isec, ipt, syn_offset)
+
+        return location
+
+    @staticmethod
+    def synlocation_to_segx(cell: bluecellulab.Cell, isec, ipt, syn_offset) -> float:
+        """Translate a synaptic (secid, ipt, offset) to a x coordinate.
+
+        Parameters
+        ----------
+        isec : integer
+               section id
+        ipt : float
+              ipt
+        syn_offset : float
+                     Synaptic offset
+
+        Returns
+        -------
+        x : float
+            The x coordinate on section with secid, where the synapse
+            can be placed
+        """
+        if syn_offset < 0.0:
+            syn_offset = 0.0
+
+        curr_sec = cell.get_hsection(isec)
+        if curr_sec is None:
+            raise Exception(
+                "No section found at isec=%d in gid %d" %
+                (isec, cell.gid))
+        length = curr_sec.L
+
+        # access section to compute the distance
+        if neuron.h.section_orientation(sec=cell.get_hsection(isec)) == 1:
+            ipt = neuron.h.n3d(sec=cell.get_hsection(isec)) - 1 - ipt
+            syn_offset = -syn_offset
+
+        distance = 0.5
+        if ipt < neuron.h.n3d(sec=cell.get_hsection(isec)):
+            distance = (neuron.h.arc3d(ipt, sec=cell.get_hsection(isec)) +
+                        syn_offset) / length
+            if distance == 0.0:
+                distance = 0.0000001
+            if distance >= 1.0:
+                distance = 0.9999999
+
+        if neuron.h.section_orientation(sec=cell.get_hsection(isec)) == 1:
+            distance = 1 - distance
+
+        if distance < 0:
+            logger.warning(f"synlocation_to_segx found negative distance \
+                        at curr_sec({neuron.h.secname(sec=curr_sec)}) syn_offset: {syn_offset}")
+            return 0.0
+        else:
+            return distance

--- a/bluecellulab/synapse/synapse_factory.py
+++ b/bluecellulab/synapse/synapse_factory.py
@@ -113,8 +113,6 @@ class SynapseFactory:
             ipt = syn_description[SynapseProperty.POST_SEGMENT_ID]
             syn_offset = syn_description[SynapseProperty.POST_SEGMENT_OFFSET]
             section = cell.get_hsection(isec)
-            if section is None:
-                raise BluecellulabError("No section found at isec=%d in gid %d" % (isec, cell.gid))
             location = cls.synlocation_to_segx(section, ipt, syn_offset)
 
         return location

--- a/bluecellulab/synapse/synapse_factory.py
+++ b/bluecellulab/synapse/synapse_factory.py
@@ -145,9 +145,7 @@ class SynapseFactory:
 
         distance = 0.5
         if ipt < neuron.h.n3d(sec=section):
-            distance = (
-                neuron.h.arc3d(ipt, sec=section) + syn_offset
-            ) / length
+            distance = (neuron.h.arc3d(ipt, sec=section) + syn_offset) / length
             if distance == 0.0:
                 distance = 0.0000001
             if distance >= 1.0:

--- a/bluecellulab/synapse/synapse_types.py
+++ b/bluecellulab/synapse/synapse_types.py
@@ -35,7 +35,6 @@ class Synapse:
             location: float,
             syn_id: tuple[str, int],
             syn_description: pd.Series,
-            base_seed: int | None,
             popids: tuple[int, int],
             extracellular_calcium: float | None = None):
         """Constructor.
@@ -47,8 +46,6 @@ class Synapse:
         syn_id : Synapse identifier, string being the projection name and
                int the synapse id. Empty string refers to a local connection
         syn_description : Parameters of the synapse
-        base_seed : Base seed of the simulation, the seeds for this synapse
-                    will be derived from this
         popids : Source and target popids used by the random number generation
         extracellular_calcium: the extracellular calcium concentration
         """
@@ -73,15 +70,7 @@ class Synapse:
         self.mech_name: str = "not-yet-defined"
         self.randseed3: Optional[int] = None
 
-        if cell.rng_settings is None:
-            self.rng_setting = bluecellulab.RNGSettings(
-                mode='Compatibility',
-                base_seed=base_seed)
-        elif base_seed is not None:
-            raise Exception('Synapse: base_seed and RNGSettings cant '
-                            'be used together')
-        else:
-            self.rng_settings = cell.rng_settings
+        self.rng_settings = cell.rng_settings
 
     @property
     def delay_weights(self) -> list[tuple[float, float]]:
@@ -234,8 +223,8 @@ class Synapse:
 
 class GluSynapse(Synapse):
 
-    def __init__(self, cell, location, syn_id, syn_description, base_seed, popids, extracellular_calcium):
-        super().__init__(cell, location, syn_id, syn_description, base_seed, popids, extracellular_calcium)
+    def __init__(self, cell, location, syn_id, syn_description, popids, extracellular_calcium):
+        super().__init__(cell, location, syn_id, syn_description, popids, extracellular_calcium)
         self.use_glusynapse_helper()
 
     def use_glusynapse_helper(self) -> None:
@@ -298,8 +287,8 @@ class GluSynapse(Synapse):
 
 class GabaabSynapse(Synapse):
 
-    def __init__(self, cell, location, syn_id, syn_description, base_seed, popids, extracellular_calcium, randomize_risetime=True):
-        super().__init__(cell, location, syn_id, syn_description, base_seed, popids, extracellular_calcium)
+    def __init__(self, cell, location, syn_id, syn_description, popids, extracellular_calcium, randomize_risetime=True):
+        super().__init__(cell, location, syn_id, syn_description, popids, extracellular_calcium)
         self.use_gabaab_helper(randomize_risetime)
 
     def use_gabaab_helper(self, randomize_gaba_risetime: bool) -> None:
@@ -383,8 +372,8 @@ class GabaabSynapse(Synapse):
 
 class AmpanmdaSynapse(Synapse):
 
-    def __init__(self, cell, location, syn_id, syn_description, base_seed, popids, extracellular_calcium):
-        super().__init__(cell, location, syn_id, syn_description, base_seed, popids, extracellular_calcium)
+    def __init__(self, cell, location, syn_id, syn_description, popids, extracellular_calcium):
+        super().__init__(cell, location, syn_id, syn_description, popids, extracellular_calcium)
         self.use_ampanmda_helper()
 
     def use_ampanmda_helper(self) -> None:

--- a/bluecellulab/tools.py
+++ b/bluecellulab/tools.py
@@ -14,8 +14,6 @@
 """Static tools for BluecellulabError."""
 
 
-# pylint: disable=R0914, R0913
-
 from __future__ import annotations
 import io
 import json
@@ -470,8 +468,6 @@ def calculate_SS_voltage_replay_subprocess(blueconfig, gid, step_level,
 class NoDaemonProcess(multiprocessing.Process):
     """Class that represents a non-daemon process."""
 
-    # pylint: disable=R0201
-
     def _get_daemon(self):
         """Get daemon flag."""
         return False
@@ -481,7 +477,6 @@ class NoDaemonProcess(multiprocessing.Process):
         pass
     daemon = property(_get_daemon, _set_daemon)  # type:ignore
 
-# pylint: disable=W0223, R0911
 
 # We sub-class multiprocessing.pool.Pool instead of multiprocessing.Pool
 # because the latter is only a wrapper function, not a proper class.
@@ -490,8 +485,6 @@ class NoDaemonProcess(multiprocessing.Process):
 class NestedPool(multiprocessing.pool.Pool):
     """Class that represents a MultiProcessing nested pool."""
     Process = NoDaemonProcess
-
-# pylint: disable=R0913
 
 
 def search_hyp_current_replay(blueconfig, gid, target_voltage=-80,
@@ -553,8 +546,6 @@ def search_hyp_current_replay(blueconfig, gid, target_voltage=-80,
                                          stop_time=stop_time,
                                          max_nestlevel=max_nestlevel,
                                          return_fullrange=return_fullrange)
-
-# pylint: enable=R0913
 
 
 class search_hyp_function:

--- a/bluecellulab/type_aliases.py
+++ b/bluecellulab/type_aliases.py
@@ -6,3 +6,4 @@ from neuron import h as hoc_type
 HocObjectType: TypeAlias = hoc_type   # until NEURON is typed, most NEURON types are this
 NeuronRNG: TypeAlias = hoc_type
 NeuronVector: TypeAlias = hoc_type
+NeuronSection: TypeAlias = hoc_type

--- a/tests/test_ballstick.py
+++ b/tests/test_ballstick.py
@@ -3,7 +3,6 @@ Synapse test file. Uses ball-and-stick models
 Models simulated in N disticnt ways, all shoudl
 """
 
-# pylint: disable=E1101,W0201
 
 import os
 

--- a/tests/test_bglib.py
+++ b/tests/test_bglib.py
@@ -1,8 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
-# pylint: disable=E1101,W0201
-
 """Unit tests for BGLib functionality"""
 
 import os

--- a/tests/test_cell/test_core.py
+++ b/tests/test_cell/test_core.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-
-# pylint: disable=E1101,W0201
-
 """Unit tests for Cell.py"""
 
 import math

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1,8 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
-# pylint: disable=E1101,W0201
-
 """Testing the loading of the bluecellulab"""
 
 import pytest

--- a/tests/test_simulation/test_simulation.py
+++ b/tests/test_simulation/test_simulation.py
@@ -1,8 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
-# pylint: disable=E1101,W0201
-
 """Tests for the Simulation class"""
 
 import pathlib

--- a/tests/test_synapse/test_synapse_factory.py
+++ b/tests/test_synapse/test_synapse_factory.py
@@ -54,12 +54,13 @@ class TestSynapseFactory:
         assert synapse.weight == connection_modifiers["Weight"]
 
     def test_determine_synapse_location(self):
-        location = SynapseFactory.determine_synapse_location(self.syn_description, self.cell)
-        assert location == 0.9999999
+        res = SynapseFactory.determine_synapse_location(self.syn_description, self.cell)
+        assert res.location == 0.9999999
         # set afferent_section_pos
         self.syn_description["afferent_section_pos"] = 1.2
-        location = SynapseFactory.determine_synapse_location(self.syn_description, self.cell)
-        assert location == 1.2
+        res = SynapseFactory.determine_synapse_location(self.syn_description, self.cell)
+        assert res.location == 1.2
+        assert res.section.L == pytest.approx(9.530376893488256)
 
 
 def test_determine_synapse_type():

--- a/tests/test_synapse/test_synapse_factory.py
+++ b/tests/test_synapse/test_synapse_factory.py
@@ -62,6 +62,16 @@ class TestSynapseFactory:
         assert res.location == 1.2
         assert res.section.L == pytest.approx(9.530376893488256)
 
+    def test_synlocation_to_segx(self):
+        ipt = 13
+        isec = 169
+        syn_offset = 1.2331762313842773
+        section = self.cell.get_hsection(isec)
+        res = SynapseFactory.synlocation_to_segx(section, ipt, syn_offset)
+        assert res == pytest.approx(0.9999999)
+        res = SynapseFactory.synlocation_to_segx(section, ipt, syn_offset=-1.0)
+        assert res == pytest.approx(0.9999999)
+
 
 def test_determine_synapse_type():
     """Unit test for determine_synapse_type."""

--- a/tests/test_synapse/test_synapse_factory.py
+++ b/tests/test_synapse/test_synapse_factory.py
@@ -30,7 +30,6 @@ def test_create_synapse():
         "%s/examples/circuit_sonata_quick_scx/components/morphologies/asc/rr110330_C3_idA.asc" % str(parent_dir),
         template_format="v6_adapted",
         emodel_properties=emodel_properties)
-    location = 0.5
     syn_id = ("a", 0)
     with open("tests/test_synapse/test-synapse-series.json") as f:
         syn_description = pd.Series(json.load(f, object_hook=synapse_property_decoder))
@@ -44,7 +43,7 @@ def test_create_synapse():
     }
 
     synapse = SynapseFactory.create_synapse(
-        cell, location, syn_id, syn_description, condition_parameters, popids, extracellular_calcium, connection_modifiers
+        cell, syn_id, syn_description, condition_parameters, popids, extracellular_calcium, connection_modifiers
     )
     assert isinstance(synapse, GluSynapse)
     assert synapse.weight == connection_modifiers["Weight"]

--- a/tests/test_synapse/test_synapse_factory.py
+++ b/tests/test_synapse/test_synapse_factory.py
@@ -19,34 +19,47 @@ parent_dir = Path(__file__).resolve().parent.parent
 
 
 @pytest.mark.v6
-def test_create_synapse():
-    """Unit test for create_synapse."""
-    emodel_properties = EmodelProperties(threshold_current=1.1433533430099487,
-                                         holding_current=1.4146618843078613,
-                                         ais_scaler=1.4561502933502197,
-                                         soma_scaler=1.0)
-    cell = Cell(
-        "%s/examples/circuit_sonata_quick_scx/components/hoc/cADpyr_L2TPC.hoc" % str(parent_dir),
-        "%s/examples/circuit_sonata_quick_scx/components/morphologies/asc/rr110330_C3_idA.asc" % str(parent_dir),
-        template_format="v6_adapted",
-        emodel_properties=emodel_properties)
-    syn_id = ("a", 0)
-    with open("tests/test_synapse/test-synapse-series.json") as f:
-        syn_description = pd.Series(json.load(f, object_hook=synapse_property_decoder))
-    condition_parameters = Conditions.init_empty()
-    popids = (0, 0)
-    extracellular_calcium = 2.0
-    connection_modifiers = {
-        'Weight': 1.15143,
-        'SpontMinis': 0.0,
-        'SynapseConfigure': ['%s.Use = 1 %s.Use_GB = 1 %s.Use_p = 1 %s.gmax0_AMPA = gmax_p_AMPA %s.rho_GB = 1 %s.rho0_GB = 1 %s.gmax_AMPA = %s.gmax_p_AMPA']
-    }
+class TestSynapseFactory:
 
-    synapse = SynapseFactory.create_synapse(
-        cell, syn_id, syn_description, condition_parameters, popids, extracellular_calcium, connection_modifiers
-    )
-    assert isinstance(synapse, GluSynapse)
-    assert synapse.weight == connection_modifiers["Weight"]
+    def setup(self):
+        emodel_properties = EmodelProperties(
+            threshold_current=1.1433533430099487,
+            holding_current=1.4146618843078613,
+            ais_scaler=1.4561502933502197,
+            soma_scaler=1.0)
+        self.cell = Cell(
+            parent_dir / "examples/circuit_sonata_quick_scx/components/hoc/cADpyr_L2TPC.hoc",
+            parent_dir / "examples/circuit_sonata_quick_scx/components/morphologies/asc/rr110330_C3_idA.asc",
+            template_format="v6_adapted",
+            emodel_properties=emodel_properties,
+        )
+        with open("tests/test_synapse/test-synapse-series.json") as f:
+            self.syn_description = pd.Series(json.load(f, object_hook=synapse_property_decoder))
+
+    def test_create_synapse(self):
+        syn_id = ("a", 0)
+        condition_parameters = Conditions.init_empty()
+        popids = (0, 0)
+        extracellular_calcium = 2.0
+        connection_modifiers = {
+            'Weight': 1.15143,
+            'SpontMinis': 0.0,
+            'SynapseConfigure': ['%s.Use = 1 %s.Use_GB = 1 %s.Use_p = 1 %s.gmax0_AMPA = gmax_p_AMPA %s.rho_GB = 1 %s.rho0_GB = 1 %s.gmax_AMPA = %s.gmax_p_AMPA']
+        }
+
+        synapse = SynapseFactory.create_synapse(
+            self.cell, syn_id, self.syn_description, condition_parameters, popids, extracellular_calcium, connection_modifiers
+        )
+        assert isinstance(synapse, GluSynapse)
+        assert synapse.weight == connection_modifiers["Weight"]
+
+    def test_determine_synapse_location(self):
+        location = SynapseFactory.determine_synapse_location(self.syn_description, self.cell)
+        assert location == 0.9999999
+        # set afferent_section_pos
+        self.syn_description["afferent_section_pos"] = 1.2
+        location = SynapseFactory.determine_synapse_location(self.syn_description, self.cell)
+        assert location == 1.2
 
 
 def test_determine_synapse_type():

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,8 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
-# pylint: disable=E1101,W0201
-
 """Unit tests for tools.py"""
 
 import json

--- a/tests/test_ttx.py
+++ b/tests/test_ttx.py
@@ -1,8 +1,5 @@
 """Unit tests for TTX in mod files"""
 
-# pylint: disable=
-
-
 import os
 
 import pytest


### PR DESCRIPTION
#### Overview
This PR introduces a set of refactorings that aim to streamline and decouple `Synapse` objects from `Cell` objects, ensuring they only access the necessary data. It also enhances explicit typing for NeuronSection objects, improving type-checking reliability.

#### Details of Changes

- **Limiting Synapse's Dependency on Cell:**
   - **Motivation:** The extensive attributes and functions of the Cell object are not fully utilized by the Synapse objects.
   - **Change:** Now, Synapse only retrieves the necessary hoc section and RNG settings from the Cell.

- **More explicit typing of Hoc parameters:**
    - Explicitly type the NeuronSection objects. There were also type errors e.g. Optional[NeuronSection] instead of NeuronSection. Typing revealed them. The PR fixed them to avoid unreachable if obj is None checks.
- **Synapse Seed Management:**
   - **Update:** Synapse objects now obtain their seed values directly from their associated Cell object
- **Base Seed and Non-Negative Enforcement:**
   - **Adaptation:** `base_seed` is constrained to be a `NonNegativeInt`, mitigating risks associated with negative seed values.
- **Unified Synapse Location Calculation:**
   - **Prior State:** `add_replay_synapses` & `add_replay_minis` independently performed synapse location calculations.
   - **Update:** Both methods now employ a common function for calculating synapse location
- **Refactoring Synapse Location and Creation Logic:**
   - **Adjustment:** `synlocation_to_segx` now takes only a `Section` instead of a full `Cell`.
   - **Shift in Responsibility:** Synapse creation logic has been transitioned from `Cell` to a new `SynapseFactory`.


### Todo

- [X] add unit tests for the new SynapseFactory methods