### PR TITLE
use typing_extensions.deprecated decorator

### DIFF
--- a/bluecellulab/cell/core.py
+++ b/bluecellulab/cell/core.py
@@ -20,12 +20,13 @@ import logging
 from pathlib import Path
 import queue
 from typing import Optional
+from typing_extensions import deprecated
 
 import numpy as np
 import pandas as pd
 
 import bluecellulab
-from bluecellulab import neuron, psection, tools
+from bluecellulab import neuron, psection
 from bluecellulab.cell.injector import InjectableMixin
 from bluecellulab.cell.plotting import PlottableMixin
 from bluecellulab.cell.section_distance import EuclideanSectionDistance
@@ -692,7 +693,7 @@ class Cell(InjectableMixin, PlottableMixin):
                                 dend found in section %s" % secname)
 
     @staticmethod
-    @tools.deprecated("bluecellulab.cell.section_distance.EuclideanSectionDistance")
+    @deprecated("Use bluecellulab.cell.section_distance.EuclideanSectionDistance instead.")
     def euclid_section_distance(
             hsection1=None,
             hsection2=None,

--- a/bluecellulab/cell/injector.py
+++ b/bluecellulab/cell/injector.py
@@ -18,9 +18,9 @@ import warnings
 import logging
 
 import numpy as np
+from typing_extensions import deprecated
 
 import bluecellulab
-from bluecellulab import tools
 from bluecellulab.cell.stimuli_generator import (
     gen_ornstein_uhlenbeck,
     gen_shotnoise_signal,
@@ -416,13 +416,13 @@ class InjectableMixin:
         currents.play(pulse._ref_amp, time)
         return currents
 
-    @tools.deprecated("inject_current_waveform")
+    @deprecated("Use inject_current_waveform instead.")
     def injectCurrentWaveform(self, t_content, i_content, section=None,
                               segx=0.5):
         """Inject a current in the cell."""
         return self.inject_current_waveform(t_content, i_content, section, segx)
 
-    @tools.deprecated("add_sin_current")
+    @deprecated("Use add_sin_current instead.")
     def addSineCurrentInject(self, start_time, stop_time, freq,
                              amplitude, mid_level, dt=1.0):
         """Add a sinusoidal current injection.

--- a/bluecellulab/tools.py
+++ b/bluecellulab/tools.py
@@ -24,7 +24,6 @@ import os
 from pathlib import Path
 import sys
 from typing import Any, Optional, Tuple
-import warnings
 import logging
 
 import numpy as np
@@ -72,30 +71,6 @@ def set_verbose_from_env() -> None:
 
 
 set_verbose_from_env()
-
-
-class deprecated:
-    """Decorator to mark a function as deprecated."""
-
-    def __init__(self, new_function=""):
-        self.new_function = new_function
-
-    def __call__(self, func):
-        def rep_func(*args, **kwargs):
-            """Replacement function."""
-            warnings.warn(
-                "Call to deprecated function {%s}. Use {%s} instead." % (
-                    func.__name__, self.new_function),
-                category=DeprecationWarning)
-            return func(*args, **kwargs)
-        rep_func.__name__ = func.__name__
-        if func.__doc__ is None or func.__doc__ == "":
-            func.__doc__ = "Deprecated"
-        rep_func.__doc__ = func.__doc__ + "\n\n         \
-                .. note:: Replaced by %s\n\n       \
-                .. deprecated:: .1\n" % self.new_function
-        rep_func.__dict__.update(func.__dict__)
-        return rep_func
 
 
 def calculate_input_resistance(


### PR DESCRIPTION
Previously bluecellulab was implementing a decorator for deprecating functions. `typing_extensions` has  a more detailed implementation of it. This PR replaced the built-in decorator with the `typing_extensions` one.

Here in the screenshot the IDE recognises that annotation and strikes through the deprecated code.
 
![typing-extensions-deprecation2](https://github.com/BlueBrain/BlueCelluLab/assets/7026020/cb0df6cf-2fea-4c84-b133-6211104cbf36)

P.S. a relevant PEP is accepted. In Python 3.13 this decorator will be built-in.
https://peps.python.org/pep-0702/