### PR TITLE
Add default value for segx param, improve docs vcs: #minor

### DIFF
--- a/bluecellulab/cell/core.py
+++ b/bluecellulab/cell/core.py
@@ -384,9 +384,9 @@ class Cell(InjectableMixin, PlottableMixin):
 
         Args:
             section: Section to record from (Neuron section pointer).
-            segx: Segment x coordinate. Specify a value between 0 and 1. 
+            segx: Segment x coordinate. Specify a value between 0 and 1.
                   0 is typically the end closest to the soma, 1 is the distal end.
-            dt: Recording time step. If not provided, the recording step will 
+            dt: Recording time step. If not provided, the recording step will
                 default to the simulator's time step.
         """
         var_name = f"neuron.h.{section.name()}({segx})._ref_v"
@@ -400,7 +400,7 @@ class Cell(InjectableMixin, PlottableMixin):
 
         Args:
             section: Section to record from (Neuron section pointer).
-            segx: Segment x coordinate. Specify a value between 0 and 1. 
+            segx: Segment x coordinate. Specify a value between 0 and 1.
                   0 is typically the end closest to the soma, 1 is the distal end.
 
         Returns:

--- a/bluecellulab/cell/core.py
+++ b/bluecellulab/cell/core.py
@@ -377,7 +377,7 @@ class Cell(InjectableMixin, PlottableMixin):
         self.add_recording("self.axonal[1](0.5)._ref_v", dt=dt)
 
     def add_voltage_recording(
-        self, section: "neuron.h.Section", segx: float, dt: Optional[float] = None
+        self, section: "neuron.h.Section", segx: float = 0.5, dt: Optional[float] = None
     ) -> None:
         """Add a voltage recording to a certain section at a given segment
         (segx).
@@ -393,7 +393,7 @@ class Cell(InjectableMixin, PlottableMixin):
         self.add_recording(var_name, dt)
 
     def get_voltage_recording(
-        self, section: "neuron.h.Section", segx: float
+        self, section: "neuron.h.Section", segx: float = 0.5
     ) -> np.ndarray:
         """Get a voltage recording for a certain section at a given segment
         (segx).
@@ -422,14 +422,14 @@ class Cell(InjectableMixin, PlottableMixin):
         """Add a voltage recording to every section of the cell."""
         all_sections = public_hoc_cell(self.cell).all
         for section in all_sections:
-            self.add_voltage_recording(section, segx=0.5, dt=self.record_dt)
+            self.add_voltage_recording(section, dt=self.record_dt)
 
     def get_allsections_voltagerecordings(self) -> dict[str, np.ndarray]:
         """Get all the voltage recordings from all the sections."""
         all_section_voltages = {}
         all_sections = public_hoc_cell(self.cell).all
         for section in all_sections:
-            recording = self.get_voltage_recording(section, segx=0.5)
+            recording = self.get_voltage_recording(section)
             all_section_voltages[section.name()] = recording
         return all_section_voltages
 

--- a/bluecellulab/cell/core.py
+++ b/bluecellulab/cell/core.py
@@ -384,8 +384,10 @@ class Cell(InjectableMixin, PlottableMixin):
 
         Args:
             section: Section to record from (Neuron section pointer).
-            segx: Segment x coordinate.
-            dt: Recording time step. If not provided, the recording step will default to the simulator's time step.
+            segx: Segment x coordinate. Specify a value between 0 and 1. 
+                  0 is typically the end closest to the soma, 1 is the distal end.
+            dt: Recording time step. If not provided, the recording step will 
+                default to the simulator's time step.
         """
         var_name = f"neuron.h.{section.name()}({segx})._ref_v"
         self.add_recording(var_name, dt)
@@ -398,7 +400,8 @@ class Cell(InjectableMixin, PlottableMixin):
 
         Args:
             section: Section to record from (Neuron section pointer).
-            segx: Segment x coordinate.
+            segx: Segment x coordinate. Specify a value between 0 and 1. 
+                  0 is typically the end closest to the soma, 1 is the distal end.
 
         Returns:
             A NumPy array containing the voltage recording values.


### PR DESCRIPTION
Addresses the issues mentioned in https://github.com/BlueBrain/BlueCelluLab/issues/126.

* adds more information on the segx param
* adds default value for segx in `add_voltage_recording` and `get_voltage_recording`