### PR TITLE
Simplify psection representation in Cell

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,30 @@
 Changelog
 ==========
 
+2.3.0
+-------
+
+* Cell class no longer serialises the following attributes
+  - secname_to_hsection
+  - secname_to_isec
+  - serialized
+  - cellname
+* The direct access to hsection option is removed. The access is through psection.
+* solves the dependency issue between init_psections and get_psections
+* avoids storing lists of NEURON sections for each Cell. Instead turns them into properties.
+* Dendrogram plotting functions are decoupled from PSection
+
+
+2.2.0
+------
+
+* Add default value for segx param, improve docs vcs: #minor (#127)
+
+2.1.0
+---------
+
+* Allow API functions to be used without loading hoc/mod (#124)
+
 2.0.0
 ---------
 

--- a/bluecellulab/cell/core.py
+++ b/bluecellulab/cell/core.py
@@ -123,7 +123,6 @@ class Cell(InjectableMixin, PlottableMixin):
                             dt=self.record_dt)
 
         self.delayed_weights = queue.PriorityQueue()  # type: ignore
-        self.secname_to_isec: dict[str, int] = {}
         self.secname_to_psection: dict[str, PSection] = {}
 
         self.emodel_properties = emodel_properties
@@ -202,7 +201,6 @@ class Cell(InjectableMixin, PlottableMixin):
                 secname = neuron.h.secname(sec=hsection)
                 self.psections[isec] = self.secname_to_psection[secname]
                 self.psections[isec].isec = isec
-                self.secname_to_isec[secname] = isec
 
         # Set the parents and children of all the psections
         for psec in self.psections.values():

--- a/bluecellulab/cell/core.py
+++ b/bluecellulab/cell/core.py
@@ -206,7 +206,7 @@ class Cell(InjectableMixin, PlottableMixin):
             return self.secname_to_psection[section_id]
         else:
             raise BluecellulabError(
-                "Section id must be an int or a str, not {type(section_id)}"
+                f"Section id must be an int or a str, not {type(section_id)}"
             )
 
     def make_passive(self) -> None:

--- a/bluecellulab/cell/core.py
+++ b/bluecellulab/cell/core.py
@@ -198,12 +198,16 @@ class Cell(InjectableMixin, PlottableMixin):
             else:
                 self.cell.re_init_rng()
 
-    def get_psection(self, section_id: int | None = None) -> PSection:
-        """Return a python section with the specified section id or name."""
-        if section_id is not None:
+    def get_psection(self, section_id: int | str) -> PSection:
+        """Return a python section with the specified section id."""
+        if isinstance(section_id, int):
             return self.psections[section_id]
+        elif isinstance(section_id, str):
+            return self.secname_to_psection[section_id]
         else:
-            raise BluecellulabError("Cell: get_psection requires or a section_id or a secname")
+            raise BluecellulabError(
+                "Section id must be an int or a str, not {type(section_id)}"
+            )
 
     def make_passive(self) -> None:
         """Make the cell passive by deactivating all the active channels."""

--- a/bluecellulab/cell/core.py
+++ b/bluecellulab/cell/core.py
@@ -124,7 +124,6 @@ class Cell(InjectableMixin, PlottableMixin):
 
         self.delayed_weights = queue.PriorityQueue()  # type: ignore
         self.secname_to_isec: dict[str, int] = {}
-        self.secname_to_hsection: dict[str, HocObjectType] = {}
         self.secname_to_psection: dict[str, PSection] = {}
 
         self.emodel_properties = emodel_properties
@@ -191,7 +190,6 @@ class Cell(InjectableMixin, PlottableMixin):
         """
         for sec in self.all:
             secname = neuron.h.secname(sec=sec)
-            self.secname_to_hsection[secname] = sec
             self.secname_to_psection[secname] = PSection(sec)
 
         # section are not serialized yet, do it now

--- a/bluecellulab/cell/core.py
+++ b/bluecellulab/cell/core.py
@@ -99,8 +99,6 @@ class Cell(InjectableMixin, PlottableMixin):
         # diameters of the loaded morph are wrong
         neuron.h.finitialize()
 
-        self.cellname = neuron.h.secname(sec=self.soma).split(".")[0]
-
         if rng_settings is None:
             self.rng_settings = RNGSettings("Random123")  # SONATA value
         else:

--- a/bluecellulab/cell/core.py
+++ b/bluecellulab/cell/core.py
@@ -156,7 +156,7 @@ class Cell(InjectableMixin, PlottableMixin):
         self.psections: dict[int, psection.PSection] = {}
 
         neuron.h.pop_section()  # Undoing soma push
-        # self.init_psections()
+        self.init_psections()
         self.sonata_proxy: Optional[SonataProxy] = None
 
     def __repr__(self) -> str:
@@ -202,6 +202,8 @@ class Cell(InjectableMixin, PlottableMixin):
 
             for hchild in psec.hchildren:
                 childname = neuron.h.secname(sec=hchild)
+                if "myelin" in childname:
+                    continue
                 pchild = self.get_psection(secname=childname)
                 psec.add_pchild(pchild)
 

--- a/bluecellulab/cell/core.py
+++ b/bluecellulab/cell/core.py
@@ -488,7 +488,8 @@ class Cell(InjectableMixin, PlottableMixin):
 
         base_seed = self.rng_settings.base_seed
         weight = syn_description[SynapseProperty.G_SYNX]
-        post_sec_id = syn_description[SynapseProperty.POST_SECTION_ID]
+        # numpy int to int
+        post_sec_id = int(syn_description[SynapseProperty.POST_SECTION_ID])
 
         location = SynapseFactory.determine_synapse_location(
             syn_description, self

--- a/bluecellulab/cell/core.py
+++ b/bluecellulab/cell/core.py
@@ -27,7 +27,7 @@ import numpy as np
 import pandas as pd
 
 import bluecellulab
-from bluecellulab import psection
+from bluecellulab.psection import PSection
 from bluecellulab.cell.injector import InjectableMixin
 from bluecellulab.cell.plotting import PlottableMixin
 from bluecellulab.cell.section_distance import EuclideanSectionDistance
@@ -126,7 +126,7 @@ class Cell(InjectableMixin, PlottableMixin):
         self.delayed_weights = queue.PriorityQueue()  # type: ignore
         self.secname_to_isec: dict[str, int] = {}
         self.secname_to_hsection: dict[str, HocObjectType] = {}
-        self.secname_to_psection: dict[str, psection.PSection] = {}
+        self.secname_to_psection: dict[str, PSection] = {}
 
         self.emodel_properties = emodel_properties
         if template_format == 'v6':
@@ -149,7 +149,7 @@ class Cell(InjectableMixin, PlottableMixin):
         # Used to know when re_init_rng() can be executed
         self.is_made_passive = False
 
-        self.psections: dict[int, psection.PSection] = {}
+        self.psections: dict[int, PSection] = {}
 
         neuron.h.pop_section()  # Undoing soma push
         self.init_psections()
@@ -194,7 +194,7 @@ class Cell(InjectableMixin, PlottableMixin):
         for hsection in self.all:
             secname = neuron.h.secname(sec=hsection)
             self.secname_to_hsection[secname] = hsection
-            self.secname_to_psection[secname] = psection.PSection(hsection)
+            self.secname_to_psection[secname] = PSection(hsection)
 
         # section are not serialized yet, do it now
         if self.serialized is None:
@@ -252,28 +252,16 @@ class Cell(InjectableMixin, PlottableMixin):
             else:
                 self.cell.re_init_rng()
 
-    def get_psection(self, section_id=None, secname=None):
-        """Return a python section with the specified section id or name.
-
-        Parameters
-        ----------
-        section_id: int
-                    Return the PSection object based on section id
-        secname: string
-                 Return the PSection object based on section name
-
-        Returns
-        -------
-        psection: PSection
-                  PSection object of the specified section id or name
-        """
+    def get_psection(
+        self, section_id: int | None = None, secname: str | None = None
+    ) -> PSection:
+        """Return a python section with the specified section id or name."""
         if section_id is not None:
             return self.psections[section_id]
         elif secname is not None:
             return self.secname_to_psection[secname]
         else:
-            raise Exception(
-                "Cell: get_psection requires or a section_id or a secname")
+            raise Exception("Cell: get_psection requires or a section_id or a secname")
 
     def get_hsection(self, section_id: int | float) -> NeuronSection:
         """Use the serialized object to find a hoc section from a section

--- a/bluecellulab/cell/core.py
+++ b/bluecellulab/cell/core.py
@@ -112,7 +112,6 @@ class Cell(InjectableMixin, PlottableMixin):
 
         self.ips: dict[SynapseID, HocObjectType] = {}
         self.syn_mini_netcons: dict[SynapseID, HocObjectType] = {}
-        self.serialized: Optional[SerializedSections] = None
 
         # Be careful when removing this,
         # time recording needs this push
@@ -191,11 +190,8 @@ class Cell(InjectableMixin, PlottableMixin):
             secname = neuron.h.secname(sec=sec)
             self.secname_to_psection[secname] = PSection(sec)
 
-        # section are not serialized yet, do it now
-        if self.serialized is None:
-            self.serialized = SerializedSections(public_hoc_cell(self.cell))
-
-        for isec, val in self.serialized.isec2sec.items():
+        serial_sections = SerializedSections(public_hoc_cell(self.cell))
+        for isec, val in serial_sections.isec2sec.items():
             hsection: NeuronSection = val.sec
             if hsection:
                 secname = neuron.h.secname(sec=hsection)

--- a/bluecellulab/cell/core.py
+++ b/bluecellulab/cell/core.py
@@ -46,6 +46,7 @@ from bluecellulab.stimuli import SynapseReplay
 from bluecellulab.synapse import SynapseFactory, Synapse
 from bluecellulab.synapse.synapse_types import SynapseID
 from bluecellulab.type_aliases import HocObjectType, NeuronSection
+from bluecellulab.utils import run_once
 
 logger = logging.getLogger(__name__)
 
@@ -183,6 +184,7 @@ class Cell(InjectableMixin, PlottableMixin):
         """Connect this cell to a circuit via sonata proxy."""
         self.sonata_proxy = sonata_proxy
 
+    @run_once
     def init_psections(self) -> None:
         """Initialize the psections list.
 

--- a/bluecellulab/cell/core.py
+++ b/bluecellulab/cell/core.py
@@ -201,7 +201,7 @@ class Cell(InjectableMixin, PlottableMixin):
             hparent = psec.hparent
             if hparent:
                 parentname = hparent.name()
-                psec.pparent = self.get_psection(secname=parentname)
+                psec.pparent = self.secname_to_psection[parentname]
             else:
                 psec.pparent = None
 
@@ -209,12 +209,8 @@ class Cell(InjectableMixin, PlottableMixin):
                 childname = hchild.name()
                 if "myelin" in childname:
                     continue
-                pchild = self.get_psection(secname=childname)
+                pchild = self.secname_to_psection[childname]
                 psec.add_pchild(pchild)
-
-    def get_section_id(self, secname: str) -> int:
-        """Returns the id of the section with name secname."""
-        return self.secname_to_psection[secname].isec
 
     def re_init_rng(self, use_random123_stochkv: bool = False) -> None:
         """Reinitialize the random number generator for stochastic channels."""
@@ -240,16 +236,12 @@ class Cell(InjectableMixin, PlottableMixin):
             else:
                 self.cell.re_init_rng()
 
-    def get_psection(
-        self, section_id: int | None = None, secname: str | None = None
-    ) -> PSection:
+    def get_psection(self, section_id: int | None = None) -> PSection:
         """Return a python section with the specified section id or name."""
         if section_id is not None:
             return self.psections[section_id]
-        elif secname is not None:
-            return self.secname_to_psection[secname]
         else:
-            raise Exception("Cell: get_psection requires or a section_id or a secname")
+            raise BluecellulabError("Cell: get_psection requires or a section_id or a secname")
 
     def make_passive(self) -> None:
         """Make the cell passive by deactivating all the active channels."""

--- a/bluecellulab/cell/core.py
+++ b/bluecellulab/cell/core.py
@@ -200,13 +200,13 @@ class Cell(InjectableMixin, PlottableMixin):
         for psec in self.psections.values():
             hparent = psec.hparent
             if hparent:
-                parentname = neuron.h.secname(sec=hparent)
+                parentname = hparent.name()
                 psec.pparent = self.get_psection(secname=parentname)
             else:
                 psec.pparent = None
 
             for hchild in psec.hchildren:
-                childname = neuron.h.secname(sec=hchild)
+                childname = hchild.name()
                 if "myelin" in childname:
                     continue
                 pchild = self.get_psection(secname=childname)

--- a/bluecellulab/cell/core.py
+++ b/bluecellulab/cell/core.py
@@ -118,11 +118,6 @@ class Cell(InjectableMixin, PlottableMixin):
         # time recording needs this push
         self.soma.push()
         self.hocname = neuron.h.secname(sec=self.soma).split(".")[0]
-        self.somatic = list(public_hoc_cell(self.cell).somatic)
-        self.basal = list(public_hoc_cell(self.cell).basal)  # dend is same as basal
-        self.apical = list(public_hoc_cell(self.cell).apical)
-        self.axonal = list(public_hoc_cell(self.cell).axonal)
-        self.all = list(public_hoc_cell(self.cell).all)
         self.record_dt = record_dt
         self.add_recordings(['self.soma(0.5)._ref_v', 'neuron.h._ref_t'],
                             dt=self.record_dt)
@@ -158,6 +153,26 @@ class Cell(InjectableMixin, PlottableMixin):
         neuron.h.pop_section()  # Undoing soma push
         self.init_psections()
         self.sonata_proxy: Optional[SonataProxy] = None
+
+    @property
+    def somatic(self) -> list[NeuronSection]:
+        return list(public_hoc_cell(self.cell).somatic)
+
+    @property
+    def basal(self) -> list[NeuronSection]:
+        return list(public_hoc_cell(self.cell).basal)
+
+    @property
+    def apical(self) -> list[NeuronSection]:
+        return list(public_hoc_cell(self.cell).apical)
+
+    @property
+    def axonal(self) -> list[NeuronSection]:
+        return list(public_hoc_cell(self.cell).axonal)
+
+    @property
+    def all(self) -> list[NeuronSection]:
+        return list(public_hoc_cell(self.cell).all)
 
     def __repr__(self) -> str:
         base_info = f"Cell Object: {super().__repr__()}"

--- a/bluecellulab/cell/plotting.py
+++ b/bluecellulab/cell/plotting.py
@@ -60,7 +60,6 @@ class PlottableMixin:
             scale_bar_size=10.0,
             fig_title=None):
         """Show a dendrogram of the cell."""
-        self.init_psections()
         cell_dendrogram = bluecellulab.Dendrogram(
             self.psections,
             variable=variable,

--- a/bluecellulab/cell/serialized_sections.py
+++ b/bluecellulab/cell/serialized_sections.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 """Module that allows morphology sections to be accessed from an array by
 index."""
-
+from __future__ import annotations
 import logging
 import warnings
 import neuron
-from bluecellulab.type_aliases import HocObjectType
+from bluecellulab.type_aliases import HocObjectType, NeuronSection
 
 
 logger = logging.getLogger(__name__)
@@ -27,7 +27,7 @@ warnings.filterwarnings("once", category=UserWarning, module=__name__)
 class SerializedSections:
 
     def __init__(self, cell: HocObjectType) -> None:
-        self.isec2sec = {}
+        self.isec2sec: dict[int, NeuronSection] = {}
         n = cell.nSecAll
 
         for index, sec in enumerate(cell.all, start=1):

--- a/bluecellulab/dendrogram.py
+++ b/bluecellulab/dendrogram.py
@@ -140,7 +140,7 @@ class Dendrogram:
         if not interactive and fig_show:
             pylab.show()
 
-    def redraw(self):
+    def redraw(self) -> None:
         """Redraw the dendrogram."""
         if self.active:
             if not self.drawCount:
@@ -150,5 +150,3 @@ class Dendrogram:
                 self.drawCount = 1
             else:
                 self.drawCount = self.drawCount - 1
-
-        return True

--- a/bluecellulab/dendrogram.py
+++ b/bluecellulab/dendrogram.py
@@ -14,8 +14,33 @@
 """Class that represents a dendrogram window."""
 
 import numpy as np
+import pylab
 
 from bluecellulab.psection import PSection
+
+
+def drawTree(psection: PSection, figure, x, y, variable=None, varbounds=None) -> None:
+    """Draw a dendritic tree."""
+    # Draw myself
+    psection.setupDraw(
+        psection.psegments, psection.maxsegdiam, figure, x, y, variable=variable, varbounds=varbounds
+    )
+
+    # Draw children
+
+    # First child is a same x coordinate
+    new_x = x  # + self.L + self.xSpacing
+
+    # Children drawn L + ySpacing heigher
+    new_y = y + psection.L + psection.ySpacing
+
+    for child in psection.pchildren:
+        drawTree(child, figure, new_x, new_y, variable=variable, varbounds=varbounds)
+        pylab.plot(
+            [x + psection.diam / 2, new_x + child.diam / 2],
+            [y + psection.L, new_y], 'k')
+        # Prepare new_x for next child
+        new_x = new_x + child.tree_width()
 
 
 class Dendrogram:
@@ -80,9 +105,9 @@ class Dendrogram:
             cbar.ax.set_yticklabels(["%.2e" % (
                 varbounds[0]), "%.2e" % (varbounds[1])])
 
-        self.proot.drawTree(self.dend_figure, self.proot.xSpacing,
-                            self.proot.ySpacing, variable=variable,
-                            varbounds=varbounds)
+        drawTree(self.proot, self.dend_figure, self.proot.xSpacing,
+                 self.proot.ySpacing, variable=variable,
+                 varbounds=varbounds)
 
         if scale_bar:
             pylab.plot(
@@ -122,7 +147,8 @@ class Dendrogram:
 
         for section in self.psections:
             section_id = section.isec
-            psections[section_id].redraw()
+            if section_id is not None:
+                psections[section_id].redraw()
 
         self.canvas = self.dend_figure.gca().figure.canvas
         self.ax = self.dend_figure.gca()

--- a/bluecellulab/dendrogram.py
+++ b/bluecellulab/dendrogram.py
@@ -57,7 +57,6 @@ class Dendrogram:
             scale_bar_size=10.0,
             fig_title=None,
             fig_show=True):
-        import pylab
 
         if interactive:
             pylab.ion()

--- a/bluecellulab/dendrogram.py
+++ b/bluecellulab/dendrogram.py
@@ -17,12 +17,25 @@ import numpy as np
 import pylab
 
 from bluecellulab.psection import PSection
+from bluecellulab.psegment import PSegment
+
+
+def setup_draw(psegments: list[PSegment], maxsegdiam: float, figure, x, y, variable=None, varbounds=None) -> None:
+    """Setup draw of psection."""
+    y_accum = 0.0
+    for psegment in psegments:
+        psegment.setupDraw(figure,
+                           x + (maxsegdiam - psegment.diam) / 2,
+                           y + y_accum,
+                           variable=variable,
+                           varbounds=varbounds)
+        y_accum += psegment.L
 
 
 def draw_tree(psection: PSection, figure, x, y, variable=None, varbounds=None) -> None:
     """Draw a dendritic tree."""
     # Draw myself
-    psection.setupDraw(
+    setup_draw(
         psection.psegments, psection.maxsegdiam, figure, x, y, variable=variable, varbounds=varbounds
     )
 
@@ -105,8 +118,8 @@ class Dendrogram:
                 varbounds[0]), "%.2e" % (varbounds[1])])
 
         draw_tree(self.proot, self.dend_figure, self.proot.xSpacing,
-                 self.proot.ySpacing, variable=variable,
-                 varbounds=varbounds)
+                  self.proot.ySpacing, variable=variable,
+                  varbounds=varbounds)
 
         if scale_bar:
             pylab.plot(

--- a/bluecellulab/dendrogram.py
+++ b/bluecellulab/dendrogram.py
@@ -19,7 +19,7 @@ import pylab
 from bluecellulab.psection import PSection
 
 
-def drawTree(psection: PSection, figure, x, y, variable=None, varbounds=None) -> None:
+def draw_tree(psection: PSection, figure, x, y, variable=None, varbounds=None) -> None:
     """Draw a dendritic tree."""
     # Draw myself
     psection.setupDraw(
@@ -35,7 +35,7 @@ def drawTree(psection: PSection, figure, x, y, variable=None, varbounds=None) ->
     new_y = y + psection.L + psection.ySpacing
 
     for child in psection.pchildren:
-        drawTree(child, figure, new_x, new_y, variable=variable, varbounds=varbounds)
+        draw_tree(child, figure, new_x, new_y, variable=variable, varbounds=varbounds)
         pylab.plot(
             [x + psection.diam / 2, new_x + child.diam / 2],
             [y + psection.L, new_y], 'k')
@@ -105,7 +105,7 @@ class Dendrogram:
             cbar.ax.set_yticklabels(["%.2e" % (
                 varbounds[0]), "%.2e" % (varbounds[1])])
 
-        drawTree(self.proot, self.dend_figure, self.proot.xSpacing,
+        draw_tree(self.proot, self.dend_figure, self.proot.xSpacing,
                  self.proot.ySpacing, variable=variable,
                  varbounds=varbounds)
 

--- a/bluecellulab/dendrogram.py
+++ b/bluecellulab/dendrogram.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Class that represents a dendrogram window."""
-
+from __future__ import annotations
 import numpy as np
 import pylab
 

--- a/bluecellulab/dendrogram.py
+++ b/bluecellulab/dendrogram.py
@@ -15,13 +15,15 @@
 
 import numpy as np
 
+from bluecellulab.psection import PSection
+
 
 class Dendrogram:
     """Class that represent a dendrogram plot."""
 
     def __init__(
             self,
-            psections,
+            psections: list[PSection],
             variable=None,
             active=False,
             save_fig_path=None,
@@ -49,14 +51,14 @@ class Dendrogram:
         # neuron.h.finitialize()
 
         # self.hroot = neuron.h.SectionRef(sec=self.sections[0]).root
-        self.proot = psections[0]
+        self.proot: PSection = psections[0]
         # self.psections = [self.proot] + self.proot.getAllPDescendants()
 
         xSpacing = self.proot.xSpacing
         ySpacing = self.proot.ySpacing
 
-        max_y = self.proot.treeHeight() + self.proot.ySpacing + title_space
-        max_x = self.proot.treeWidth() + self.proot.xSpacing + scale_bar_size
+        max_y = self.proot.tree_height() + self.proot.ySpacing + title_space
+        max_x = self.proot.tree_width() + self.proot.xSpacing + scale_bar_size
         pylab.xlim([0, max_x])
         pylab.ylim([0, max_y])
         pylab.gca().set_xticks([])

--- a/bluecellulab/dendrogram.py
+++ b/bluecellulab/dendrogram.py
@@ -56,6 +56,12 @@ def draw_tree(psection: PSection, figure, x, y, variable=None, varbounds=None) -
         new_x = new_x + child.tree_width()
 
 
+def redraw_psection(psection: PSection) -> None:
+    """Redraw psection."""
+    for psegment in psection.psegments:
+        psegment.redraw()
+
+
 class Dendrogram:
     """Class that represent a dendrogram plot."""
 
@@ -160,7 +166,7 @@ class Dendrogram:
         for section in self.psections:
             section_id = section.isec
             if section_id is not None:
-                psections[section_id].redraw()
+                redraw_psection(psections[section_id])
 
         self.canvas = self.dend_figure.gca().figure.canvas
         self.ax = self.dend_figure.gca()
@@ -183,7 +189,7 @@ class Dendrogram:
         if self.active:
             if not self.drawCount:
                 for psection in self.psections:
-                    psection.redraw()
+                    redraw_psection(psection)
                 self.canvas.blit(self.ax.bbox)
                 self.drawCount = 1
             else:

--- a/bluecellulab/dendrogram.py
+++ b/bluecellulab/dendrogram.py
@@ -50,9 +50,8 @@ class Dendrogram:
         self.psections = psections
         # neuron.h.finitialize()
 
-        # self.hroot = neuron.h.SectionRef(sec=self.sections[0]).root
         self.proot: PSection = psections[0]
-        # self.psections = [self.proot] + self.proot.getAllPDescendants()
+        self.psections = [self.proot] + self.proot.all_descendants()
 
         xSpacing = self.proot.xSpacing
         ySpacing = self.proot.ySpacing
@@ -121,8 +120,9 @@ class Dendrogram:
 
         self.dend_figure.canvas.draw()
 
-        for secid in self.psections:
-            psections[secid].redraw()
+        for section in self.psections:
+            section_id = section.isec
+            psections[section_id].redraw()
 
         self.canvas = self.dend_figure.gca().figure.canvas
         self.ax = self.dend_figure.gca()

--- a/bluecellulab/psection.py
+++ b/bluecellulab/psection.py
@@ -123,12 +123,13 @@ class PSection:
         """Add a python represent of a child section."""
         self.pchildren.append(pchild)
 
-    def setupDraw(self, figure, x, y, variable=None, varbounds=None):
+    @staticmethod
+    def setupDraw(psegments, maxsegdiam, figure, x, y, variable=None, varbounds=None):
         """Setup draw of psection."""
         y_accum = 0
-        for psegment in self.psegments:
+        for psegment in psegments:
             psegment.setupDraw(figure,
-                               x + (self.maxsegdiam - psegment.diam) / 2,
+                               x + (maxsegdiam - psegment.diam) / 2,
                                y + y_accum,
                                variable=variable,
                                varbounds=varbounds)
@@ -171,30 +172,6 @@ class PSection:
         for child in self.pchildren:
             pdescendants += child.all_descendants()
         return pdescendants
-
-    def drawTree(self, figure, x, y, variable=None, varbounds=None):
-        """Draw a dendritic tree."""
-        import pylab
-
-        # Draw myself
-        self.setupDraw(figure, x, y, variable=variable, varbounds=varbounds)
-
-        # Draw children
-
-        # First child is a same x coordinate
-        new_x = x  # + self.L + self.xSpacing
-
-        # Children drawn L + ySpacing heigher
-        new_y = y + self.L + self.ySpacing
-
-        for child in self.pchildren:
-            child.drawTree(
-                figure, new_x, new_y, variable=variable, varbounds=varbounds)
-            pylab.plot(
-                [x + self.diam / 2, new_x + child.diam / 2],
-                [y + self.L, new_y], 'k')
-            # Prepare new_x for next child
-            new_x = new_x + child.tree_width()
 
     def tree_width(self) -> float:
         """Width of a dendritic tree."""

--- a/bluecellulab/psection.py
+++ b/bluecellulab/psection.py
@@ -194,18 +194,18 @@ class PSection:
                 [x + self.diam / 2, new_x + child.diam / 2],
                 [y + self.L, new_y], 'k')
             # Prepare new_x for next child
-            new_x = new_x + child.treeWidth()
+            new_x = new_x + child.tree_width()
 
-    def treeWidth(self):
+    def tree_width(self) -> float:
         """Width of a dendritic tree."""
         if self.is_leaf:
-            treeWidth = self.maxsegdiam + self.xSpacing
+            width = self.maxsegdiam + self.xSpacing
         else:
-            treeWidth = sum(child.treeWidth() for child in self.pchildren)
-        return max(self.diam + self.xSpacing, treeWidth)
+            width = sum(child.tree_width() for child in self.pchildren)
+        return max(self.diam + self.xSpacing, width)
 
-    def treeHeight(self):
+    def tree_height(self) -> float:
         """Height of dendritic tree."""
         return self.L + self.ySpacing + \
-            (max([child.treeHeight() for child in self.pchildren])
+            (max([child.tree_height() for child in self.pchildren])
              if self.pchildren else 0)

--- a/bluecellulab/psection.py
+++ b/bluecellulab/psection.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Represents a python version of NEURON Section (for drawing)."""
-
+from __future__ import annotations
 import neuron
 
 import bluecellulab
@@ -59,12 +59,12 @@ class PSection:
         self.ySpacing = 5
 
     @property
-    def isLeaf(self):
+    def is_leaf(self) -> bool:
         """Return true if section is a leaf in the morphological structure."""
         return not self.hchildren
 
     @property
-    def hparent(self):
+    def hparent(self) -> NeuronSection | None:
         """Return the hoc section of the parent."""
         if self.href.has_parent():
             return self.href.parent
@@ -72,12 +72,12 @@ class PSection:
             return None
 
     @property
-    def hchildren(self):
+    def hchildren(self) -> list[NeuronSection]:
         """Return a list with the hoc sections of the children."""
         return [self.href.child[index] for index in
                 range(0, int(self.href.nchild()))]
 
-    def add_pchild(self, pchild):
+    def add_pchild(self, pchild) -> None:
         """Add a python represent of a child section."""
         self.pchildren.append(pchild)
 
@@ -156,7 +156,7 @@ class PSection:
 
     def treeWidth(self):
         """Width of a dendritic tree."""
-        if self.isLeaf:
+        if self.is_leaf:
             treeWidth = self.maxsegdiam + self.xSpacing
         else:
             treeWidth = sum(child.treeWidth() for child in self.pchildren)

--- a/bluecellulab/psection.py
+++ b/bluecellulab/psection.py
@@ -64,14 +64,14 @@ def init_psections(
 class PSection:
     """Class that represents a cell section."""
 
-    def __init__(self, hsection, isec=None):
-        self.L = hsection.L
-        self.diam = hsection.diam
-        self.hsection: NeuronSection = hsection
-        self.name = neuron.h.secname(sec=hsection)
-        self.href = neuron.h.SectionRef(sec=self.hsection)
-        self.pparent = None
-        self.pchildren = []
+    def __init__(self, hsection: NeuronSection, isec: int | None = None):
+        self.L: float = hsection.L
+        self.diam: float = hsection.diam
+        self.hsection = hsection
+        self.name: str = neuron.h.secname(sec=hsection)
+        self.href: NeuronSection = neuron.h.SectionRef(sec=self.hsection)
+        self.pparent: PSection | None = None
+        self.pchildren: list[PSection] = []
         self.isec = isec
 
         if 'apic' in self.name:

--- a/bluecellulab/psection.py
+++ b/bluecellulab/psection.py
@@ -16,6 +16,7 @@
 import neuron
 
 import bluecellulab
+from bluecellulab.type_aliases import NeuronSection
 
 
 class PSection:
@@ -24,7 +25,7 @@ class PSection:
     def __init__(self, hsection, isec=None):
         self.L = hsection.L
         self.diam = hsection.diam
-        self.hsection = hsection
+        self.hsection: NeuronSection = hsection
         self.name = neuron.h.secname(sec=hsection)
         self.href = neuron.h.SectionRef(sec=self.hsection)
         self.pparent = None

--- a/bluecellulab/psection.py
+++ b/bluecellulab/psection.py
@@ -129,7 +129,7 @@ class PSection:
         varmin = None
         varmax = None
         for psegment in self.psegments:
-            value = psegment.getVariableValue(variable)
+            value = psegment.get_variable_value(variable)
             if value:
                 varmin = min(value, varmin) if varmin else value
                 varmax = max(value, varmax) if varmax else value

--- a/bluecellulab/psection.py
+++ b/bluecellulab/psection.py
@@ -17,6 +17,7 @@ import neuron
 
 import bluecellulab
 from bluecellulab.cell.serialized_sections import SerializedSections
+from bluecellulab.psegment import PSegment
 from bluecellulab.type_aliases import HocObjectType, NeuronSection
 
 
@@ -89,7 +90,7 @@ class PSection:
                 "PSection: Section of unknown type: %s" %
                 self.name)
 
-        self.psegments = []
+        self.psegments: list[PSegment] = []
         self.maxsegdiam = 0.0
         for hsegment in hsection:
             # psegment = bluecellulab.PSegment(hsection(hsegment.x), self)
@@ -122,18 +123,6 @@ class PSection:
     def add_pchild(self, pchild) -> None:
         """Add a python represent of a child section."""
         self.pchildren.append(pchild)
-
-    @staticmethod
-    def setupDraw(psegments, maxsegdiam, figure, x, y, variable=None, varbounds=None):
-        """Setup draw of psection."""
-        y_accum = 0
-        for psegment in psegments:
-            psegment.setupDraw(figure,
-                               x + (maxsegdiam - psegment.diam) / 2,
-                               y + y_accum,
-                               variable=variable,
-                               varbounds=varbounds)
-            y_accum += psegment.L
 
     def redraw(self):
         """Redraw psection."""

--- a/bluecellulab/psection.py
+++ b/bluecellulab/psection.py
@@ -165,11 +165,11 @@ class PSection:
 
         return varbounds
 
-    def getAllPDescendants(self):
+    def all_descendants(self) -> list[PSection]:
         """Return all the psection that are descendants of this psection."""
         pdescendants = list(self.pchildren)
         for child in self.pchildren:
-            pdescendants += child.getAllPDescendants()
+            pdescendants += child.all_descendants()
         return pdescendants
 
     def drawTree(self, figure, x, y, variable=None, varbounds=None):

--- a/bluecellulab/psection.py
+++ b/bluecellulab/psection.py
@@ -120,9 +120,10 @@ class PSection:
         return [self.href.child[index] for index in
                 range(0, int(self.href.nchild()))]
 
-    def add_pchild(self, pchild) -> None:
+    def add_pchild(self, pchild: PSection) -> None:
         """Add a python represent of a child section."""
         self.pchildren.append(pchild)
+        pchild.pparent = self
 
     def getSectionVarBounds(self, variable):
         """Get bounds a variable in a section."""

--- a/bluecellulab/psection.py
+++ b/bluecellulab/psection.py
@@ -90,15 +90,15 @@ class PSection:
                 self.name)
 
         self.psegments = []
-        self.maxsegdiam = 0
+        self.maxsegdiam = 0.0
         for hsegment in hsection:
             # psegment = bluecellulab.PSegment(hsection(hsegment.x), self)
             psegment = bluecellulab.PSegment(hsegment, self)
             self.psegments.append(psegment)
             self.maxsegdiam = max(self.maxsegdiam, psegment.diam)
 
-        self.xSpacing = 1
-        self.ySpacing = 5
+        self.xSpacing = 1.0
+        self.ySpacing = 5.0
 
     @property
     def is_leaf(self) -> bool:

--- a/bluecellulab/psection.py
+++ b/bluecellulab/psection.py
@@ -124,11 +124,6 @@ class PSection:
         """Add a python represent of a child section."""
         self.pchildren.append(pchild)
 
-    def redraw(self):
-        """Redraw psection."""
-        for psegment in self.psegments:
-            psegment.redraw()
-
     def getSectionVarBounds(self, variable):
         """Get bounds a variable in a section."""
         varmin = None

--- a/bluecellulab/psection.py
+++ b/bluecellulab/psection.py
@@ -209,7 +209,3 @@ class PSection:
         return self.L + self.ySpacing + \
             (max([child.treeHeight() for child in self.pchildren])
              if self.pchildren else 0)
-
-    def getHChildren(self):
-        """All hoc children of a section."""
-        return self.hchildren

--- a/bluecellulab/psegment.py
+++ b/bluecellulab/psegment.py
@@ -61,7 +61,7 @@ class PSegment:
     def redraw(self):
         """Redraw a segment."""
         if self.plotvariable:
-            plotvariable_value = self.getVariableValue(self.plotvariable)
+            plotvariable_value = self.get_variable_value(self.plotvariable)
             if plotvariable_value is not None:
                 self.patch.set_facecolor(self.color_map(
                     (plotvariable_value - self.varbounds[0]) /
@@ -71,7 +71,7 @@ class PSegment:
                 self.patch.set_hatch("/")
             self.ax.draw_artist(self.patch)
 
-    def getVariableValue(self, variable):
+    def get_variable_value(self, variable):
         """Get a variable value in a segment."""
         if variable == "v" or neuron.h.execute1(
             "{%s.%s(%f)}"

--- a/bluecellulab/synapse/synapse_factory.py
+++ b/bluecellulab/synapse/synapse_factory.py
@@ -110,7 +110,7 @@ class SynapseFactory:
     @classmethod
     def determine_synapse_location(cls, syn_description: pd.Series, cell: bluecellulab.Cell) -> SynapseHocArgs:
         """Returns the location of the synapse."""
-        isec = syn_description[SynapseProperty.POST_SECTION_ID]
+        isec = int(syn_description[SynapseProperty.POST_SECTION_ID])  # numpy int to int
         section: NeuronSection = cell.get_psection(section_id=isec).hsection
 
         # old circuits don't have it, it needs to be computed via synlocation_to_segx

--- a/bluecellulab/synapse/synapse_factory.py
+++ b/bluecellulab/synapse/synapse_factory.py
@@ -111,7 +111,7 @@ class SynapseFactory:
     def determine_synapse_location(cls, syn_description: pd.Series, cell: bluecellulab.Cell) -> SynapseHocArgs:
         """Returns the location of the synapse."""
         isec = syn_description[SynapseProperty.POST_SECTION_ID]
-        section = cell.get_hsection(isec)
+        section: NeuronSection = cell.get_psection(section_id=isec).hsection
 
         # old circuits don't have it, it needs to be computed via synlocation_to_segx
         if ("afferent_section_pos" in syn_description and

--- a/tests/test_cell/test_core.py
+++ b/tests/test_cell/test_core.py
@@ -88,10 +88,17 @@ class TestCellBaseClass1:
 
     def test_get_psection(self):
         """Cell: Test cell.get_psection"""
+        idx = 0
+        name = "Cell[0].soma[0]"
         assert isinstance(
-            self.cell.get_psection(0).hsection, neuron.nrn.Section)
+            self.cell.get_psection(idx).hsection, neuron.nrn.Section)
+        assert isinstance(
+            self.cell.get_psection(name).hsection, neuron.nrn.Section)
+        assert self.cell.get_psection(idx) == self.cell.get_psection(name)
         with pytest.raises(BluecellulabError):
             self.cell.get_psection(None)
+        with pytest.raises(BluecellulabError):
+            self.cell.get_psection(5.8673453123)
 
     def test_add_recording(self):
         """Cell: Test cell.add_recording"""

--- a/tests/test_cell/test_core.py
+++ b/tests/test_cell/test_core.py
@@ -366,6 +366,31 @@ class TestCellV6:
         res = self.cell.get_parentsection(section)
         assert res == self.cell.soma
 
+    def test_somatic_sections(self):
+        """Test that somatic property returns a non-empty list sections."""
+        assert isinstance(self.cell.somatic, list)
+        assert len(self.cell.somatic) > 0
+
+    def test_basal_sections(self):
+        """Test that basal property returns a non-empty list of sections."""
+        assert isinstance(self.cell.basal, list)
+        assert len(self.cell.basal) > 0
+
+    def test_apical_sections(self):
+        """Test that apical property returns a non-empty list sections."""
+        assert isinstance(self.cell.apical, list)
+        assert len(self.cell.apical) > 0
+
+    def test_axonal_sections(self):
+        """Test that axonal property returns a non-empty list of sections."""
+        assert isinstance(self.cell.axonal, list)
+        assert len(self.cell.axonal) > 0
+
+    def test_all_sections(self):
+        """Test that the all property returns a non-empty list of all sections."""
+        assert isinstance(self.cell.all, list)
+        assert len(self.cell.all) > 0
+
 
 @pytest.mark.v6
 def test_add_synapse_replay():

--- a/tests/test_cell/test_core.py
+++ b/tests/test_cell/test_core.py
@@ -86,10 +86,10 @@ class TestCellBaseClass1:
         assert math.fabs(self.cell.apical[10].diam - 0.95999) < 0.00001
         assert math.fabs(self.cell.apical[10].L - 23.73195) < 0.00001
 
-    def test_get_hsection(self):
-        """Cell: Test cell.get_hsection"""
+    def test_get_psection(self):
+        """Cell: Test cell.get_psection"""
         assert isinstance(
-            self.cell.get_hsection(0), neuron.nrn.Section)
+            self.cell.get_psection(0).hsection, neuron.nrn.Section)
 
     def test_add_recording(self):
         """Cell: Test cell.add_recording"""

--- a/tests/test_cell/test_core.py
+++ b/tests/test_cell/test_core.py
@@ -90,6 +90,8 @@ class TestCellBaseClass1:
         """Cell: Test cell.get_psection"""
         assert isinstance(
             self.cell.get_psection(0).hsection, neuron.nrn.Section)
+        with pytest.raises(BluecellulabError):
+            self.cell.get_psection(None)
 
     def test_add_recording(self):
         """Cell: Test cell.add_recording"""
@@ -326,14 +328,6 @@ class TestCellV6:
         # NEURON ID: cADpyr_L2TPC_bluecellulab_0x7f73b48e2510.
         # make sure NEURON template name is in the string representation
         assert self.cell.cell.hname().split('[')[0] in str(self.cell)
-
-    def test_get_section_id(self):
-        """Test the get_section_id method."""
-        self.cell.init_psections()
-        assert self.cell.get_section_id(str(self.cell.soma)) == 0
-        assert self.cell.get_section_id(str(self.cell.axonal[0])) == 1
-        assert self.cell.get_section_id(str(self.cell.basal[0])) == 145
-        assert self.cell.get_section_id(str(self.cell.apical[0])) == 169
 
     def test_area(self):
         """Test the cell's area computation."""

--- a/tests/test_psection.py
+++ b/tests/test_psection.py
@@ -1,0 +1,80 @@
+"""Unit tests for the psection module."""
+
+import pytest
+from pathlib import Path
+from bluecellulab import Cell, EmodelProperties
+from bluecellulab.psection import init_psections
+from bluecellulab.cell.template import public_hoc_cell
+
+
+parent_dir = Path(__file__).resolve().parent
+
+
+class TestPSection:
+    """Test class for testing Cell object functionalities with v6 template."""
+
+    @pytest.fixture(autouse=True)
+    def setup_method(self):
+        """Setup."""
+        emodel_properties = EmodelProperties(
+            threshold_current=1.1433533430099487,
+            holding_current=1.4146618843078613,
+            AIS_scaler=1.4561502933502197,
+            soma_scaler=1.0
+        )
+        self.cell = Cell(
+            f"{parent_dir}/examples/circuit_sonata_quick_scx/components/hoc/cADpyr_L2TPC.hoc",
+            f"{parent_dir}/examples/circuit_sonata_quick_scx/components/morphologies/asc/rr110330_C3_idA.asc",
+            template_format="v6",
+            emodel_properties=emodel_properties
+        )
+        self.psections, self.secname_to_psection = init_psections(public_hoc_cell(self.cell.cell))
+
+    def test_is_leaf(self):
+        """Test the is_leaf property for leaf and non-leaf sections."""
+        leaf_section = self.psections[245]
+        non_leaf_section = self.psections[1]
+        assert leaf_section.is_leaf
+        assert not non_leaf_section.is_leaf
+
+    def test_hparent_and_hchildren(self):
+        """Test hparent and hchildren properties for a section with a parent and children."""
+        root = self.psections[0]
+        assert root.hparent is None
+        a_section = self.psections[145]
+        assert a_section.hparent is not None
+        assert len(a_section.hchildren) > 0
+        leaf_section = self.psections[245]
+        assert len(leaf_section.hchildren) == 0
+
+    def test_add_pchild(self):
+        """Test adding a child section."""
+        parent_section = self.psections[245]  # leaf
+        assert len(parent_section.pchildren) == 0
+        child_section = self.psections[244]  # leaf
+        parent_section.add_pchild(child_section)
+        assert child_section in parent_section.pchildren
+        assert child_section.pparent == parent_section
+
+    def test_all_descendants(self):
+        """Test retrieving all descendants of a section."""
+        root_section = self.psections[0]
+        all_descendants = root_section.all_descendants()
+        # Excluding the root and myelin sections: -1 + -1 = -2
+        assert len(all_descendants) == len(self.psections) - 2
+
+    def test_tree_width(self):
+        """Test calculation of tree width."""
+        tree_width = self.psections[0].tree_width()
+        assert tree_width > 0
+
+    def test_tree_height(self):
+        """Test calculation of tree height."""
+        tree_height = self.psections[0].tree_height()
+        assert tree_height > 0
+
+    def test_init_psections(self):
+        """Test if psections and secname_to_psection are properly initialized."""
+        assert len(self.psections) > 0
+        assert len(self.secname_to_psection) > 0
+        assert len(self.psections) == len(self.secname_to_psection)

--- a/tests/test_synapse/test_synapse_factory.py
+++ b/tests/test_synapse/test_synapse_factory.py
@@ -67,7 +67,7 @@ class TestSynapseFactory:
         ipt = 13
         isec = 169
         syn_offset = 1.2331762313842773
-        section = self.cell.get_hsection(isec)
+        section = self.cell.get_psection(isec).hsection
         res = SynapseFactory.synlocation_to_segx(section, ipt, syn_offset)
         assert res == pytest.approx(0.9999999)
         res = SynapseFactory.synlocation_to_segx(section, ipt, syn_offset=-1.0)


### PR DESCRIPTION
### Changes

+ Simplifies the NEURON sections representation in `Cell`.
+ The direct access to hsection option is removed. The access is through psection.
+ Addresses https://github.com/BlueBrain/BlueCelluLab/issues/128
+ solves the dependency issue between `init_psections` and `get_psections` (i.e. error if user wants to access get_psections without calling init_psections)
+ avoids storing lists of NEURON sections for each Cell. Instead turns them into property methods.

+ Removes the following attributes from `Cell`. Every functionality can be accomplished without storing these.
  - secname_to_hsection
  - secname_to_isec
  - serialized
  - cellname

### Remaining

- [x] Write unit tests for `psections.py`
- [x] Update CHANGELOG