### PR TITLE
CI: pass CODECOV token in release->test workflow call

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   call-test-workflow:
     uses: BlueBrain/BlueCelluLab/.github/workflows/test.yml@main
+    with:
+      token: ${{ secrets.CODECOV_TOKEN }}
 
   build-and-publish:
     name: Build, publish on PyPI and make a GitHub release


### PR DESCRIPTION
### Issue

The coverage was only getting updated for the PR branches not main.

### Reason

For security reasons when we call a workflow from the other we need to specify the env vars.

To upload the coverage of the main we do 2 workflow calls.
1) release.yml -> test.yml
2) test.yml -> codecov's workflow

### Solution

Previously in 2, the secret is passed. In 1 it was not. Now both of them pass.