### PR TITLE
migrate pkg_resources -> importlib.resources

### DIFF
--- a/bluecellulab/cell/ballstick/__init__.py
+++ b/bluecellulab/cell/ballstick/__init__.py
@@ -1,11 +1,11 @@
 """A simple ball and stick model."""
 
-import pkg_resources
+from importlib import resources
 from bluecellulab.cell import Cell
 
 
 def create_ball_stick() -> Cell:
     """Creates a ball and stick model by using package's hoc and asc."""
-    hoc = pkg_resources.resource_filename("bluecellulab", "cell/ballstick/emodel.hoc")
-    morphology = pkg_resources.resource_filename("bluecellulab", "cell/ballstick/morphology.asc")
+    hoc = resources.files("bluecellulab") / "cell/ballstick/emodel.hoc"
+    morphology = resources.files("bluecellulab") / "cell/ballstick/morphology.asc"
     return Cell(template_path=hoc, morphology_path=morphology)

--- a/bluecellulab/cell/ballstick/__init__.py
+++ b/bluecellulab/cell/ballstick/__init__.py
@@ -1,6 +1,6 @@
 """A simple ball and stick model."""
 
-from importlib import resources
+import importlib_resources as resources
 from bluecellulab.cell import Cell
 
 

--- a/bluecellulab/importer.py
+++ b/bluecellulab/importer.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 """Main importer of bluecellulab."""
 
+from importlib import resources
 import logging
 import os
 from types import ModuleType
-import pkg_resources
 
 import neuron
 
@@ -62,7 +62,7 @@ def import_neurodamus(neuron: ModuleType) -> None:
     ]
 
     for hoc_file in hoc_files:
-        hoc_file_path = pkg_resources.resource_filename("bluecellulab", f"hoc/{hoc_file}")
+        hoc_file_path = str(resources.files("bluecellulab") / f"hoc/{hoc_file}")
         neuron.h.load_file(hoc_file_path)
 
 

--- a/bluecellulab/importer.py
+++ b/bluecellulab/importer.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Main importer of bluecellulab."""
 
-from importlib import resources
+import importlib_resources as resources
 import logging
 import os
 from types import ModuleType

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from pathlib import Path
 import pytest
 from types import ModuleType
 from unittest.mock import MagicMock, patch
@@ -51,16 +52,16 @@ def test_import_mod_lib_no_env_with_folder():
 
 
 @patch.object(
-    importer.pkg_resources,
-    "resource_filename",
-    return_value="/fake/path/to/hoc_file.hoc",
+    importer.resources,
+    "files",
+    return_value=Path("/fake/path/"),
 )
-def test_import_neurodamus(mocked_pkg_resources):
+def test_import_neurodamus(mocked_resources):
     mock_neuron = MagicMock()
     importer.import_neurodamus(mock_neuron)
     assert mock_neuron.h.load_file.called
     # Check that it was called with the expected arguments
-    mock_neuron.h.load_file.assert_any_call("/fake/path/to/hoc_file.hoc")
+    mock_neuron.h.load_file.assert_any_call("/fake/path/hoc/Cell.hoc")
 
 
 def test_print_header(caplog):


### PR DESCRIPTION
pkg_resources is deprecated. 
https://docs.python.org/3/library/importlib.resources.html#module-importlib.resources
https://importlib-resources.readthedocs.io/en/latest/migration.html