### PR TITLE
Use CaptureOutput to forward hoc's stdout to logger.debug

### DIFF
--- a/bluecellulab/importer.py
+++ b/bluecellulab/importer.py
@@ -21,7 +21,7 @@ from types import ModuleType
 import neuron
 
 from bluecellulab.exceptions import BluecellulabError
-from bluecellulab.utils import run_once
+from bluecellulab.utils import CaptureOutput, run_once
 
 
 logger = logging.getLogger(__name__)
@@ -63,7 +63,9 @@ def import_neurodamus(neuron: ModuleType) -> None:
 
     for hoc_file in hoc_files:
         hoc_file_path = str(resources.files("bluecellulab") / f"hoc/{hoc_file}")
-        neuron.h.load_file(hoc_file_path)
+        with CaptureOutput() as stdoud:
+            neuron.h.load_file(hoc_file_path)
+            logger.debug(f"Loaded {hoc_file}. stdout from the hoc: {stdoud}")
 
 
 def print_header(neuron: ModuleType, mod_lib_path: str) -> None:

--- a/bluecellulab/tools.py
+++ b/bluecellulab/tools.py
@@ -15,14 +15,12 @@
 
 
 from __future__ import annotations
-import io
 import json
 import math
 import multiprocessing
 import multiprocessing.pool
 import os
 from pathlib import Path
-import sys
 from typing import Any, Optional, Tuple
 import logging
 
@@ -32,6 +30,7 @@ import numpy as np
 import bluecellulab
 from bluecellulab.circuit.circuit_access import EmodelProperties
 from bluecellulab.exceptions import UnsteadyCellError
+from bluecellulab.utils import CaptureOutput
 
 logger = logging.getLogger(__name__)
 
@@ -652,21 +651,9 @@ class NumpyEncoder(json.JSONEncoder):
         return json.JSONEncoder.default(self, obj)
 
 
-class get_stdout(list):
-    def __enter__(self):
-        self.orig_stdout = sys.stdout
-        sys.stdout = self.stringio = io.StringIO()
-        return self
-
-    def __exit__(self, *args):
-        self.extend(self.stringio.getvalue().splitlines())
-        del self.stringio
-        sys.stdout = self.orig_stdout
-
-
 def check_empty_topology() -> bool:
     """Return true if NEURON simulator topology command is empty."""
-    with get_stdout() as stdout:
+    with CaptureOutput() as stdout:
         neuron.h.topology()
 
     return stdout == ['', '']

--- a/bluecellulab/utils.py
+++ b/bluecellulab/utils.py
@@ -1,4 +1,6 @@
 """Utility functions."""
+import contextlib
+import io
 
 
 def run_once(func):
@@ -9,3 +11,15 @@ def run_once(func):
             return func(*args, **kwargs)
     wrapper.has_run = False
     return wrapper
+
+
+class CaptureOutput(list):
+    def __enter__(self):
+        self._stringio = io.StringIO()
+        self._redirect_stdout = contextlib.redirect_stdout(self._stringio)
+        self._redirect_stdout.__enter__()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self._redirect_stdout.__exit__(exc_type, exc_val, exc_tb)
+        self.extend(self._stringio.getvalue().splitlines())

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -7,8 +7,9 @@ import numpy as np
 import pytest
 
 import bluecellulab
+from bluecellulab.cell.ballstick import create_ball_stick
 from bluecellulab.circuit.circuit_access import EmodelProperties
-from bluecellulab.tools import NumpyEncoder, Singleton, template_accepts_cvode
+from bluecellulab.tools import NumpyEncoder, Singleton, template_accepts_cvode, check_empty_topology
 
 script_dir = Path(__file__).parent
 
@@ -229,3 +230,10 @@ class TestOnSonataCircuit:
         )
         assert i_hold == pytest.approx(-0.03160848349)
         assert v_control == pytest.approx(v_hold)
+
+
+def test_check_empty_topology():
+    """Unit test for the check_empty_topology function."""
+    assert check_empty_topology() is True
+    cell = create_ball_stick()
+    assert check_empty_topology() is False

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,4 @@
-from bluecellulab.utils import run_once
+from bluecellulab.utils import CaptureOutput, run_once
 
 
 # Decorated function for testing
@@ -24,3 +24,20 @@ def test_run_once_execution():
     assert counter[0] == 1
 
     assert increment_counter(counter) is None
+
+
+def test_capture_output():
+    with CaptureOutput() as output:
+        print("Hello, World!")
+        print("This is a test.")
+
+    assert len(output) == 2
+    assert "Hello, World!" in output
+    assert "This is a test." in output
+
+
+def test_no_output():
+    with CaptureOutput() as output:
+        pass  # No output
+
+    assert len(output) == 0


### PR DESCRIPTION

This should solve #4 . Could you check @arnaudon, @eleftherioszisis ?
You should be able to see the hoc specific outputs when logger mode is set to debug.

E.g.
```
DEBUG:bluecellulab.importer:Loaded Cell.hoc. stdout from the hoc: []
DEBUG:bluecellulab.importer:Loaded TDistFunc.hoc. stdout from the hoc: []
DEBUG:bluecellulab.importer:Loaded TStim.hoc. stdout from the hoc: []
```