### PR TITLE
rm debugtest mark, tests are equally debuggable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,6 @@ markers = [
     "v6: tests on the neocortex circuit version 6.",
     "thal: tests on the thalamus circuit.",
     "unit: unit tests.",
-    "debugtest: test for debugging purposes.",
 ]
 
 [tool.mypy]

--- a/tests/test_cell/test_core.py
+++ b/tests/test_cell/test_core.py
@@ -189,7 +189,7 @@ class TestCellBaseClass1:
             assert distance_euclid == distance_hand
 
 
-@pytest.mark.debugtest
+@pytest.mark.v5
 class TestCellBaseClassVClamp:
 
     """First Cell test class"""


### PR DESCRIPTION
It is an old pytest mark from the times some tests on large networks were requiring access to the data stored at the supercomputer.