### PR TITLE
further restrict IsolatedProcess by setting multiprocessing start method

### DIFF
--- a/bluecellulab/simulation/parallel.py
+++ b/bluecellulab/simulation/parallel.py
@@ -12,7 +12,7 @@ class IsolatedProcess(Pool):
     Use this when running isolated NEURON simulations. Running 2 NEURON
     simulations on a single process is to be avoided. Required global
     NEURON simulation parameters will automatically be passed to each
-    worker. `fork` mode of multiprocessing is used to pass the other 
+    worker. `fork` mode of multiprocessing is used to pass the other
     required global NEURON parameters to each worker.
     """
 

--- a/bluecellulab/simulation/parallel.py
+++ b/bluecellulab/simulation/parallel.py
@@ -1,6 +1,7 @@
 """Controlled simulations in parallel."""
 
 from __future__ import annotations
+import multiprocessing
 from multiprocessing.pool import Pool
 from bluecellulab.simulation.neuron_globals import NeuronGlobals
 
@@ -11,7 +12,8 @@ class IsolatedProcess(Pool):
     Use this when running isolated NEURON simulations. Running 2 NEURON
     simulations on a single process is to be avoided. Required global
     NEURON simulation parameters will automatically be passed to each
-    worker.
+    worker. `fork` mode of multiprocessing is used to pass the other 
+    required global NEURON parameters to each worker.
     """
 
     def __init__(self, processes: int | None = 1):
@@ -21,12 +23,14 @@ class IsolatedProcess(Pool):
             processes: The number of processes to use for running the simulations.
                        If set to None, then the number returned by os.cpu_count() is used.
         """
+        ctx = multiprocessing.get_context("fork")
         neuron_global_params = NeuronGlobals.get_instance().export_params()
         super().__init__(
             processes=processes,
             initializer=self.init_worker,
             initargs=(neuron_global_params,),
             maxtasksperchild=1,
+            context=ctx,
         )
 
     @staticmethod

--- a/bluecellulab/simulation/parallel.py
+++ b/bluecellulab/simulation/parallel.py
@@ -12,8 +12,8 @@ class IsolatedProcess(Pool):
     Use this when running isolated NEURON simulations. Running 2 NEURON
     simulations on a single process is to be avoided. Required global
     NEURON simulation parameters will automatically be passed to each
-    worker. `fork` mode of multiprocessing is used to pass the other
-    required global NEURON parameters to each worker.
+    worker. `fork` mode of multiprocessing is used to pass any other
+    global NEURON parameters to each worker.
     """
 
     def __init__(self, processes: int | None = 1):


### PR DESCRIPTION
This is to ensure all workers of `IsolatedProcess`s are going to be started via the `fork` mode, not the `spawn` mode.
Note: fork mode passes the parameters from the parent to child. Spawn does not (it leads to unexpected results when used with NEURON).
Source: https://github.com/neuronsimulator/nrn/issues/2842#issuecomment-2099841365