### PR TITLE
Fix: handle edge case in synapse location calculation with syn_description

### DIFF
--- a/bluecellulab/psegment.py
+++ b/bluecellulab/psegment.py
@@ -25,7 +25,7 @@ class PSegment:
 
     def __init__(self, hsegment, parentsection):
         # import matplotlib as plt
-        from matplotlib import cm
+        from matplotlib import colormaps
 
         self.hsegment = hsegment
         self.parentsection = parentsection
@@ -35,7 +35,7 @@ class PSegment:
         self.figure = None
         self.figX = None
         self.figY = None
-        self.color_map = cm.get_cmap("hot")
+        self.color_map = colormaps["hot"]
         self.ax = None
         self.patch = None
         self.plotvariable = None

--- a/bluecellulab/synapse/synapse_factory.py
+++ b/bluecellulab/synapse/synapse_factory.py
@@ -118,6 +118,10 @@ class SynapseFactory:
                 not np.isnan(syn_description[SynapseProperty.AFFERENT_SECTION_POS])):
             # position is pre computed in SONATA
             location = syn_description[SynapseProperty.AFFERENT_SECTION_POS]
+            if location == 0.0:
+                location = 0.0000001
+            elif location >= 1.0:
+                location = 0.9999999
         else:
             ipt = syn_description[SynapseProperty.POST_SEGMENT_ID]
             syn_offset = syn_description[SynapseProperty.POST_SEGMENT_OFFSET]

--- a/tests/test_synapse/test_synapse_factory.py
+++ b/tests/test_synapse/test_synapse_factory.py
@@ -60,8 +60,11 @@ class TestSynapseFactory:
         # set afferent_section_pos
         self.syn_description[SynapseProperty.AFFERENT_SECTION_POS] = 1.2
         res = SynapseFactory.determine_synapse_location(self.syn_description, self.cell)
-        assert res.location == 1.2
+        assert res.location == 0.9999999
         assert res.section.L == pytest.approx(9.530376893488256)
+        self.syn_description[SynapseProperty.AFFERENT_SECTION_POS] = 0
+        res = SynapseFactory.determine_synapse_location(self.syn_description, self.cell)
+        assert res.location == 0.0000001
 
     def test_synlocation_to_segx(self):
         ipt = 13


### PR DESCRIPTION
When retrieving the synapse location through `syn_description`, we did not properly handle cases where the location is 0. In NEURON, you cannot insert a synapse or any point process at the start (position 0) or end (position 1) of a segment if it needs an ion e.g. na, k, ca, cl etc. The section location must be strictly within the bounds (0, 1), excluding both endpoints.