### PR TITLE
Refactor: remove deprecated source population field in SynapseReplay

### DIFF
--- a/bluecellulab/cell/core.py
+++ b/bluecellulab/cell/core.py
@@ -719,27 +719,26 @@ class Cell(InjectableMixin, PlottableMixin):
             pre_gid = CellId(
                 source_population, int(synapse.syn_description[SynapseProperty.PRE_GID])
             )
-            if self.sonata_proxy.circuit_access.target_contains_cell(stimulus.source, pre_gid):
-                if pre_gid.id in synapse_spikes:
-                    spikes_of_interest = synapse_spikes[pre_gid.id]
-                    # filter spikes of interest >=stimulus.delay, <=stimulus.duration
-                    spikes_of_interest = spikes_of_interest[
-                        (spikes_of_interest >= stimulus.delay)
-                        & (spikes_of_interest <= stimulus.duration)
-                    ]
-                    connection = bluecellulab.Connection(
-                        synapse,
-                        pre_spiketrain=spikes_of_interest,
-                        pre_cell=None,
-                        stim_dt=self.record_dt,
-                        spike_threshold=spike_threshold,
-                        spike_location=spike_location,
-                    )
-                    logger.debug(
-                        f"Added synapse replay from {pre_gid} to {self.cell_id.id}, {synapse_id}"
-                    )
+            if pre_gid.id in synapse_spikes:
+                spikes_of_interest = synapse_spikes[pre_gid.id]
+                # filter spikes of interest >=stimulus.delay, <=stimulus.duration
+                spikes_of_interest = spikes_of_interest[
+                    (spikes_of_interest >= stimulus.delay)
+                    & (spikes_of_interest <= stimulus.duration)
+                ]
+                connection = bluecellulab.Connection(
+                    synapse,
+                    pre_spiketrain=spikes_of_interest,
+                    pre_cell=None,
+                    stim_dt=self.record_dt,
+                    spike_threshold=spike_threshold,
+                    spike_location=spike_location,
+                )
+                logger.debug(
+                    f"Added synapse replay from {pre_gid} to {self.cell_id.id}, {synapse_id}"
+                )
 
-                    self.connections[synapse_id] = connection
+                self.connections[synapse_id] = connection
 
     @property
     def info_dict(self):

--- a/bluecellulab/circuit/simulation_access.py
+++ b/bluecellulab/circuit/simulation_access.py
@@ -172,7 +172,7 @@ class SonataSimulationAccess:
 
 
 def get_synapse_replay_spikes(f_name: str) -> dict:
-    """Read the .dat file containing the spike replays."""
+    """Read the .h5 file containing the spike replays."""
     with h5py.File(f_name, 'r') as f:
         # Access the timestamps and node_ids datasets
         timestamps = f['/spikes/All/timestamps'][:]

--- a/bluecellulab/stimulus/circuit_stimulus_definitions.py
+++ b/bluecellulab/stimulus/circuit_stimulus_definitions.py
@@ -243,7 +243,6 @@ class Stimulus:
                 delay=stimulus_entry["delay"],
                 duration=stimulus_entry["duration"],
                 spike_file=stimulus_entry["spike_file"],
-                source=stimulus_entry["source"],
             )
         elif pattern == Pattern.SHOT_NOISE:
             return ShotNoise(
@@ -331,7 +330,6 @@ class RelativeLinear(Stimulus):
 @dataclass(frozen=True, config=dict(extra="forbid"))
 class SynapseReplay(Stimulus):
     spike_file: str
-    source: str
 
     @field_validator("spike_file")
     @classmethod

--- a/tests/test_stimulus/test_circuit_stimulus_definitions.py
+++ b/tests/test_stimulus/test_circuit_stimulus_definitions.py
@@ -10,7 +10,6 @@ def test_synapse_replay_validator():
     with pytest.raises(ValidationError):
         _ = SynapseReplay(
             target="target1",
-            source="source1",
             delay=0,
             duration=3000,
             spike_file="file_that_does_not_exist.dat",


### PR DESCRIPTION
The `source` population field is no longer required for spike replay stimuli following the transition of synapse replay files to the h5 format.