### PR TITLE
Replace memory addresses with UUIDs to enhance the uniqueness of template_name

### DIFF
--- a/bluecellulab/cell/template.py
+++ b/bluecellulab/cell/template.py
@@ -21,6 +21,7 @@ from pathlib import Path
 import re
 import string
 from typing import NamedTuple, Optional
+import uuid
 
 import neuron
 
@@ -126,8 +127,8 @@ class NeuronTemplate:
         # templates load outside of bluecellulab
         template_name = "%s_bluecellulab" % template_name
         template_name = get_neuron_compliant_template_name(template_name)
-        obj_address = hex(id(self))
-        template_name = f"{template_name}_{obj_address}"
+        unique_id = uuid.uuid4().hex
+        template_name = f"{template_name}_{unique_id}"
 
         template_content = re.sub(
             r"begintemplate\s*(\S*)",

--- a/tests/test_cell/test_core.py
+++ b/tests/test_cell/test_core.py
@@ -17,6 +17,8 @@ import math
 import random
 import warnings
 from pathlib import Path
+from unittest.mock import Mock, patch
+import uuid
 
 import neuron
 import numpy as np
@@ -47,13 +49,17 @@ def test_longname():
 
 
 @pytest.mark.v5
-def test_load_template():
+@patch('uuid.uuid4')
+def test_load_template(mock_uuid):
     """Test the neuron template loading."""
+    id = '12345678123456781234567812345678'
+    mock_uuid.return_value = uuid.UUID(id)
+
     hoc_path = parent_dir / "examples/cell_example1/test_cell.hoc"
     morph_path = parent_dir / "examples/cell_example1/test_cell.asc"
     template = NeuronTemplate(hoc_path, morph_path, "v5", None)
     template_name = template.template_name
-    assert template_name == f"test_cell_bluecellulab_{hex(id(template))}"
+    assert template_name == f"test_cell_bluecellulab_{id}"
 
 
 def test_shorten_and_hash_string():

--- a/tests/test_cell/test_core.py
+++ b/tests/test_cell/test_core.py
@@ -17,7 +17,7 @@ import math
 import random
 import warnings
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 import uuid
 
 import neuron

--- a/tests/test_cell/test_template.py
+++ b/tests/test_cell/test_template.py
@@ -14,7 +14,8 @@
 """Unit tests for template.py module."""
 
 from pathlib import Path
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
+import uuid
 
 import pytest
 
@@ -43,12 +44,16 @@ v6_morph_path = (
     examples_dir / "circuit_sonata_quick_scx" / "components" / "morphologies" / "asc" / "rr110330_C3_idA.asc"
 )
 
-
-def test_get_cell_with_bluepyopt_template():
+@patch('uuid.uuid4')
+def test_get_cell_with_bluepyopt_template(mock_uuid):
     """Unit test for the get_cell method with bluepyopt_template."""
+
+    id = '12345678123456781234567812345678'
+    mock_uuid.return_value = uuid.UUID(id)
     template = NeuronTemplate(hipp_hoc_path, hipp_morph_path, "bluepyopt", None)
     cell = template.get_cell(gid=None)
-    assert cell.hname() == f"bACnoljp_bluecellulab_{(hex(id(template)))}[0]"
+
+    assert cell.hname() == f"bACnoljp_bluecellulab_{id}[0]"
 
 
 def test_neuron_template_init():

--- a/tests/test_cell/test_template.py
+++ b/tests/test_cell/test_template.py
@@ -44,6 +44,7 @@ v6_morph_path = (
     examples_dir / "circuit_sonata_quick_scx" / "components" / "morphologies" / "asc" / "rr110330_C3_idA.asc"
 )
 
+
 @patch('uuid.uuid4')
 def test_get_cell_with_bluepyopt_template(mock_uuid):
     """Unit test for the get_cell method with bluepyopt_template."""


### PR DESCRIPTION
Aims to address https://github.com/BlueBrain/BlueCelluLab/issues/209 by reducing template redefinition issues through the use of UUIDs instead of memory addresses. While not 100% collision-proof, this change improves uniqueness.